### PR TITLE
[Feat/#234] 장소 검색 UI 구현 및 API 연결 (네이버)

### DIFF
--- a/app/src/main/java/com/acon/acon/navigation/nested/UploadNavigation.kt
+++ b/app/src/main/java/com/acon/acon/navigation/nested/UploadNavigation.kt
@@ -4,6 +4,7 @@ import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavGraphBuilder
@@ -104,8 +105,8 @@ internal fun NavGraphBuilder.uploadNavigation(
                 onNavigateBack = navController::popBackStack,
                 modifier = Modifier
                     .background(AconTheme.color.Gray900)
-                    .systemBarsPadding()
                     .fillMaxSize()
+                    .navigationBarsPadding()
             )
         }
     }

--- a/app/src/main/java/com/acon/acon/navigation/nested/UploadNavigation.kt
+++ b/app/src/main/java/com/acon/acon/navigation/nested/UploadNavigation.kt
@@ -102,7 +102,13 @@ internal fun NavGraphBuilder.uploadNavigation(
             }
         ) {
             UploadPlaceScreen(
-                onNavigateBack = navController::popBackStack,
+                onNavigateHome = {
+                    navController.navigate(SpotRoute.Graph) {
+                        popUpTo(UploadRoute.Search) {
+                            inclusive = true
+                        }
+                    }
+                },
                 modifier = Modifier
                     .background(AconTheme.color.Gray900)
                     .fillMaxSize()

--- a/core/common/src/main/java/com/acon/acon/core/common/AuthQualifiers.kt
+++ b/core/common/src/main/java/com/acon/acon/core/common/AuthQualifiers.kt
@@ -16,9 +16,16 @@ annotation class Naver
 
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
+annotation class NaverDevelopers
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
 annotation class TokenInterceptor
 
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
 annotation class NaverAuthInterceptor
 
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class NaverDevelopersAuthInterceptor

--- a/core/common/src/main/java/com/acon/acon/core/common/URLs.kt
+++ b/core/common/src/main/java/com/acon/acon/core/common/URLs.kt
@@ -9,4 +9,5 @@ object UrlConstants {
     const val NAVER_MAP = "market://details?id=com.nhn.android.nmap"
     const val NAVER_OPEN_API = "https://naveropenapi.apigw.ntruss.com/"
     const val NAVER_DEVELOPERS_OPEN_API = "https://openapi.naver.com"
+    const val ACON_INSTARGRAM = "https://www.instagram.com/acon.drop?utm_source=ig_web_button_share_sheet&igsh=ZDNlZDc0MzIxNw=="
 }

--- a/core/common/src/main/java/com/acon/acon/core/common/URLs.kt
+++ b/core/common/src/main/java/com/acon/acon/core/common/URLs.kt
@@ -8,4 +8,5 @@ object UrlConstants {
     const val ERROR_REPORT = "https://walla.my/survey/ekYLYwpJv2d0Eznnijla"
     const val NAVER_MAP = "market://details?id=com.nhn.android.nmap"
     const val NAVER_OPEN_API = "https://naveropenapi.apigw.ntruss.com/"
+    const val NAVER_DEVELOPERS_OPEN_API = "https://openapi.naver.com"
 }

--- a/core/designsystem/src/main/java/com/acon/acon/core/designsystem/component/popup/CustomToast.kt
+++ b/core/designsystem/src/main/java/com/acon/acon/core/designsystem/component/popup/CustomToast.kt
@@ -1,0 +1,76 @@
+package com.acon.acon.core.designsystem.component.popup
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.acon.acon.core.designsystem.theme.AconTheme
+import kotlinx.coroutines.delay
+
+@Composable
+fun CustomToast(
+    message: String,
+    modifier: Modifier = Modifier,
+    durationMillis: Long = 3000,
+    onDismiss: () -> Unit = {}
+) {
+    var isVisible by remember { mutableStateOf(true) }
+
+    LaunchedEffect(Unit) {
+        delay(durationMillis)
+        if (isVisible) {
+            isVisible = false
+            onDismiss()
+        }
+    }
+
+    AnimatedVisibility(
+        visible = isVisible,
+        enter = fadeIn(),
+        exit = fadeOut()
+    ) {
+        Box(
+            modifier = modifier
+                .fillMaxSize()
+        ) {
+            AconToastPopup(
+                modifier = Modifier
+                    .align(Alignment.TopCenter),
+                color = AconTheme.color.DimDefault.copy(alpha = 0.8f),
+                content = {
+                    Text(
+                        text = message,
+                        color = AconTheme.color.White,
+                        style = AconTheme.typography.Body1,
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier.padding(vertical = 13.dp)
+                    )
+                }
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun CustomToastPreview() {
+    AconTheme {
+        CustomToast(
+            message = "message"
+        )
+    }
+}

--- a/core/designsystem/src/main/res/values/strings.xml
+++ b/core/designsystem/src/main/res/values/strings.xml
@@ -11,6 +11,8 @@
     <string name="remove">삭제</string>
     <string name="select">선택</string>
     <string name="submit">제출하기</string>
+    <string name="end">끝내기</string>
+    <string name="report">제보하기</string>
     <string name="continue_writing">계속 작성</string>
     <string name="next">다음</string>
     <string name="previous">이전</string>
@@ -215,10 +217,8 @@
     <string name="upload_place_select_cafe_sub_title">중복선택이 가능해요</string>
     <string name="upload_place_select_cafe_option1">네, 작업하기 좋아요</string>
     <string name="upload_place_select_cafe_option2">아니요, 그저 그래요</string>
-    <string name="upload_place_select_cafe_option_1">작업하기 좋아요</string>
-    <string name="upload_place_select_cafe_option_2">프랜차이즈 예요</string>
     <string name="upload_place_select_restaurant_title">여긴 어떤 식당인가요??</string>
-    <string name="upload_place_select_restaurant_cafe">작업하기 좋은 카페인가요??</string>
+    <string name="upload_place_select_restaurant_cafe">작업하기 좋은 카페인가요?</string>
     <string name="upload_place_select_price_title">가성비는 어떤 편인가요?</string>
     <string name="upload_place_select_price_option_1">가성비 최고예요</string>
     <string name="upload_place_select_price_option_2">보통이에요</string>
@@ -230,6 +230,8 @@
     <string name="upload_place_enter_menu_placeholder">메뉴를 입력해주세요</string>
     <string name="upload_place_no_search_result">검색결과가 없습니다.</string>
     <string name="upload_place_no_search_try_again">확인 후 다시 입력해주세요.</string>
+    <string name="upload_place_limit_dialog_title">장소 등록 마감</string>
+    <string name="upload_place_limit_dialog_content">오늘 너무 많은 장소가 등록돼서\n새로운 장소 등록이 불가능해요.\nAcon Instargram을 통해 제보할 수 있어요.</string>
 
     <!-- Onboarding -->
     <string name="request_dislike_food_title">싫어하는 음식을\n알려줄 수 있나요?</string>

--- a/core/designsystem/src/main/res/values/strings.xml
+++ b/core/designsystem/src/main/res/values/strings.xml
@@ -228,6 +228,8 @@
     <string name="upload_place_complete_sub_title">등록한 장소는 검토 후 반영돼요</string>
     <string name="upload_place_enter_menu_title">추천하는\n메뉴를 알려주세요</string>
     <string name="upload_place_enter_menu_placeholder">메뉴를 입력해주세요</string>
+    <string name="upload_place_no_search_result">검색결과가 없습니다.</string>
+    <string name="upload_place_no_search_try_again">확인 후 다시 입력해주세요.</string>
 
     <!-- Onboarding -->
     <string name="request_dislike_food_title">싫어하는 음식을\n알려줄 수 있나요?</string>

--- a/core/designsystem/src/main/res/values/strings.xml
+++ b/core/designsystem/src/main/res/values/strings.xml
@@ -232,6 +232,7 @@
     <string name="upload_place_no_search_try_again">확인 후 다시 입력해주세요.</string>
     <string name="upload_place_limit_dialog_title">장소 등록 마감</string>
     <string name="upload_place_limit_dialog_content">오늘 너무 많은 장소가 등록돼서\n새로운 장소 등록이 불가능해요.\nAcon Instargram을 통해 제보할 수 있어요.</string>
+    <string name="upload_place_image_limit_toast">이미지는 최대 10장까지 넣을 수 있어요</string>
 
     <!-- Onboarding -->
     <string name="request_dislike_food_title">싫어하는 음식을\n알려줄 수 있나요?</string>

--- a/core/model/src/main/java/com/acon/acon/core/model/model/upload/SearchedSpotByMap.kt
+++ b/core/model/src/main/java/com/acon/acon/core/model/model/upload/SearchedSpotByMap.kt
@@ -1,9 +1,13 @@
 package com.acon.acon.core.model.model.upload
 
 import kotlinx.serialization.Serializable
+import java.util.UUID
 
 @Serializable
 data class SearchedSpotByMap(
     val title: String,
-    val address: String
+    val category: String,
+    val address: String,
+    val roadAddress: String,
+    val id: String = UUID.randomUUID().toString()
 )

--- a/core/model/src/main/java/com/acon/acon/core/model/model/upload/SearchedSpotByMap.kt
+++ b/core/model/src/main/java/com/acon/acon/core/model/model/upload/SearchedSpotByMap.kt
@@ -1,0 +1,9 @@
+package com.acon.acon.core.model.model.upload
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SearchedSpotByMap(
+    val title: String,
+    val address: String
+)

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -19,6 +19,8 @@ android {
         buildConfigField("String", "BASE_URL", "\"${localProperties["BASE_URL"]}\"")
         buildConfigField("String", "NAVER_CLIENT_ID", "\"${localProperties["naver_client_id"]}\"")
         buildConfigField("String", "NAVER_CLIENT_SECRET", "\"${localProperties["naver_client_secret"]}\"")
+        buildConfigField("String", "NAVER_DEVELOPERS_CLIENT_ID", "\"${localProperties["naver_developers_client_id"]}\"")
+        buildConfigField("String", "NAVER_DEVELOPERS_CLIENT_SECRET", "\"${localProperties["naver_developers_client_secret"]}\"")
     }
 }
 

--- a/data/src/main/kotlin/com/acon/acon/data/api/remote/MapSearchApi.kt
+++ b/data/src/main/kotlin/com/acon/acon/data/api/remote/MapSearchApi.kt
@@ -8,7 +8,7 @@ interface MapSearchApi {
     @GET("/v1/search/local.json")
     suspend fun fetchMapSearch(
         @Query("query") query: String,
-        @Query("display") display: Int = 10,
+        @Query("display") display: Int = 5,
         @Query("sort") sort: String = "random"
     ): MapSearchResponse
 }

--- a/data/src/main/kotlin/com/acon/acon/data/api/remote/MapSearchApi.kt
+++ b/data/src/main/kotlin/com/acon/acon/data/api/remote/MapSearchApi.kt
@@ -1,0 +1,14 @@
+package com.acon.acon.data.api.remote
+
+import com.acon.acon.data.dto.response.MapSearchResponse
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface MapSearchApi {
+    @GET("/v1/search/local.json")
+    suspend fun fetchMapSearch(
+        @Query("query") query: String,
+        @Query("display") display: Int = 10,
+        @Query("sort") sort: String = "random"
+    ): MapSearchResponse
+}

--- a/data/src/main/kotlin/com/acon/acon/data/datasource/remote/MapSearchRemoteDataSource.kt
+++ b/data/src/main/kotlin/com/acon/acon/data/datasource/remote/MapSearchRemoteDataSource.kt
@@ -1,0 +1,12 @@
+package com.acon.acon.data.datasource.remote
+
+import com.acon.acon.data.api.remote.MapSearchApi
+import javax.inject.Inject
+
+class MapSearchRemoteDataSource @Inject constructor(
+    private val mapSearchApi: MapSearchApi
+) {
+    suspend fun fetchMapSearch(
+        query: String
+    ) = mapSearchApi.fetchMapSearch(query)
+}

--- a/data/src/main/kotlin/com/acon/acon/data/di/ApiModule.kt
+++ b/data/src/main/kotlin/com/acon/acon/data/di/ApiModule.kt
@@ -2,9 +2,11 @@ package com.acon.acon.data.di
 
 import com.acon.acon.core.common.Auth
 import com.acon.acon.core.common.Naver
+import com.acon.acon.core.common.NaverDevelopers
 import com.acon.acon.core.common.NoAuth
 import com.acon.acon.data.api.remote.noauth.AconAppNoAuthApi
 import com.acon.acon.data.api.remote.MapApi
+import com.acon.acon.data.api.remote.MapSearchApi
 import com.acon.acon.data.api.remote.auth.OnboardingAuthApi
 import com.acon.acon.data.api.remote.auth.ProfileAuthApi
 import com.acon.acon.data.api.remote.auth.SpotAuthApi
@@ -85,6 +87,14 @@ internal object ApiModule {
         @Naver retrofit: Retrofit
     ): MapApi {
         return retrofit.create(MapApi::class.java)
+    }
+
+    @Singleton
+    @Provides
+    fun provideMapSearchApi(
+        @NaverDevelopers retrofit: Retrofit
+    ): MapSearchApi {
+        return retrofit.create(MapSearchApi::class.java)
     }
 
     @Singleton

--- a/data/src/main/kotlin/com/acon/acon/data/di/RepositoryModule.kt
+++ b/data/src/main/kotlin/com/acon/acon/data/di/RepositoryModule.kt
@@ -4,6 +4,7 @@ import com.acon.acon.data.session.SessionHandler
 import com.acon.acon.data.session.SessionHandlerImpl
 import com.acon.acon.data.repository.AconAppRepositoryImpl
 import com.acon.acon.data.repository.MapRepositoryImpl
+import com.acon.acon.data.repository.MapSearchRepositoryImpl
 import com.acon.acon.data.repository.OnboardingRepositoryImpl
 import com.acon.acon.data.repository.ProfileRepositoryImpl
 import com.acon.acon.data.repository.SpotRepositoryImpl
@@ -11,6 +12,7 @@ import com.acon.acon.data.repository.UploadRepositoryImpl
 import com.acon.acon.data.repository.UserRepositoryImpl
 import com.acon.acon.domain.repository.AconAppRepository
 import com.acon.acon.domain.repository.MapRepository
+import com.acon.acon.domain.repository.MapSearchRepository
 import com.acon.acon.domain.repository.OnboardingRepository
 import com.acon.acon.domain.repository.ProfileRepository
 import com.acon.acon.domain.repository.SpotRepository
@@ -67,6 +69,12 @@ internal abstract class RepositoryModule {
     abstract fun bindsMapRepository(
         impl: MapRepositoryImpl
     ): MapRepository
+
+    @Singleton
+    @Binds
+    abstract fun bindsMapSearchRepository(
+        impl: MapSearchRepositoryImpl
+    ): MapSearchRepository
 
     @Singleton
     @Binds

--- a/data/src/main/kotlin/com/acon/acon/data/dto/response/MapSearchResponse.kt
+++ b/data/src/main/kotlin/com/acon/acon/data/dto/response/MapSearchResponse.kt
@@ -1,0 +1,15 @@
+package com.acon.acon.data.dto.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class MapSearchResponse(
+    @SerialName("items") val placeList: List<MapSearchPlaceResponse>
+)
+
+@Serializable
+data class MapSearchPlaceResponse(
+    @SerialName("title") val title: String,
+    @SerialName("address") val address: String
+)

--- a/data/src/main/kotlin/com/acon/acon/data/dto/response/MapSearchResponse.kt
+++ b/data/src/main/kotlin/com/acon/acon/data/dto/response/MapSearchResponse.kt
@@ -11,5 +11,7 @@ data class MapSearchResponse(
 @Serializable
 data class MapSearchPlaceResponse(
     @SerialName("title") val title: String,
-    @SerialName("address") val address: String
+    @SerialName("category") val category: String,
+    @SerialName("address") val address: String,
+    @SerialName("roadAddress") val roadAddress: String
 )

--- a/data/src/main/kotlin/com/acon/acon/data/repository/MapSearchRepositoryImpl.kt
+++ b/data/src/main/kotlin/com/acon/acon/data/repository/MapSearchRepositoryImpl.kt
@@ -1,0 +1,24 @@
+package com.acon.acon.data.repository
+
+import android.text.Html
+import com.acon.acon.core.model.model.upload.SearchedSpotByMap
+import com.acon.acon.data.datasource.remote.MapSearchRemoteDataSource
+import com.acon.acon.data.error.runCatchingWith
+import com.acon.acon.domain.repository.MapSearchRepository
+import javax.inject.Inject
+
+class MapSearchRepositoryImpl @Inject constructor(
+    private val mapSearchRemoteDataSource: MapSearchRemoteDataSource
+) : MapSearchRepository {
+
+    override suspend fun fetchMapSearch(query: String): Result<List<SearchedSpotByMap>> {
+        return runCatchingWith {
+            mapSearchRemoteDataSource.fetchMapSearch(query).placeList.map {
+                SearchedSpotByMap(
+                    title = Html.fromHtml(it.title, Html.FROM_HTML_MODE_LEGACY).toString(),
+                    address = it.address
+                )
+            }
+        }
+    }
+}

--- a/data/src/main/kotlin/com/acon/acon/data/repository/MapSearchRepositoryImpl.kt
+++ b/data/src/main/kotlin/com/acon/acon/data/repository/MapSearchRepositoryImpl.kt
@@ -18,6 +18,11 @@ class MapSearchRepositoryImpl @Inject constructor(
                 }
 
                 foodCategory?.let {
+//                    Log.e("로그", "foodCategory : ${place.title}")
+//                    Log.e("로그", "foodCategory : ${it}")
+//                    Log.e("로그", "foodCategory : ${place.address}")
+//                    Log.e("로그", "foodCategory : ${place.roadAddress}")
+
                     SearchedSpotByMap(
                         title = place.title
                             .replace("<b>", "")
@@ -34,8 +39,8 @@ class MapSearchRepositoryImpl @Inject constructor(
 
     companion object {
         private val FOOD_CATEGORIES = listOf(
-            "베트남음식", "태국음식", "인도음식",
-            "한식", "중식", "일식", "양식", "분식", "술집"
+            "베트남음식", "태국음식", "인도음식", "한식", "중식", "일식", "양식", "분식",
+            "술집", "카페", "음식점"
         )
     }
 }

--- a/data/src/main/kotlin/com/acon/acon/data/repository/MapSearchRepositoryImpl.kt
+++ b/data/src/main/kotlin/com/acon/acon/data/repository/MapSearchRepositoryImpl.kt
@@ -13,25 +13,26 @@ class MapSearchRepositoryImpl @Inject constructor(
     override suspend fun fetchMapSearch(query: String): Result<List<SearchedSpotByMap>> {
         return runCatchingWith {
             mapSearchRemoteDataSource.fetchMapSearch(query).placeList.mapNotNull { place ->
-                val foodCategory = FOOD_CATEGORIES.findLast { category ->
+                val hasAnyFoodCategory = FOOD_CATEGORIES.any { category ->
                     place.category.contains(category, ignoreCase = true)
                 }
 
-                foodCategory?.let {
-//                    Log.e("로그", "foodCategory : ${place.title}")
-//                    Log.e("로그", "foodCategory : ${it}")
-//                    Log.e("로그", "foodCategory : ${place.address}")
-//                    Log.e("로그", "foodCategory : ${place.roadAddress}")
+                if (hasAnyFoodCategory) {
+                    val selectedCategory = FOOD_CATEGORIES.findLast { category ->
+                        place.category.contains(category, ignoreCase = true)
+                    }
 
                     SearchedSpotByMap(
                         title = place.title
                             .replace("<b>", "")
                             .replace("</b>", "")
                             .replace("\\/", "/"),
-                        category = it,
+                        category = selectedCategory ?: "",
                         address = place.address,
                         roadAddress = place.roadAddress
                     )
+                } else {
+                    null
                 }
             }
         }
@@ -39,7 +40,7 @@ class MapSearchRepositoryImpl @Inject constructor(
 
     companion object {
         private val FOOD_CATEGORIES = listOf(
-            "베트남음식", "태국음식", "인도음식", "한식", "중식", "일식", "양식", "분식",
+            "이탈리아음식", "베트남음식", "태국음식", "인도음식", "한식", "중식", "일식", "양식", "분식",
             "술집", "카페", "음식점"
         )
     }

--- a/domain/src/main/java/com/acon/acon/domain/repository/MapSearchRepository.kt
+++ b/domain/src/main/java/com/acon/acon/domain/repository/MapSearchRepository.kt
@@ -1,0 +1,9 @@
+package com.acon.acon.domain.repository
+
+import com.acon.acon.core.model.model.upload.SearchedSpotByMap
+
+interface MapSearchRepository {
+    suspend fun fetchMapSearch(
+        query: String
+    ): Result<List<SearchedSpotByMap>>
+}

--- a/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/UploadPlaceViewModel.kt
+++ b/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/UploadPlaceViewModel.kt
@@ -104,8 +104,8 @@ class UploadPlaceViewModel @Inject constructor(
         searchPlaceQueryFlow.value = query
     }
 
-    fun onSearchSpotByMapClicked(searchedSpotByMap: SearchedSpotByMap, onSuccess: () -> Unit) = intent {
-        onSuccess()
+    fun onSearchSpotByMapClicked(searchedSpotByMap: SearchedSpotByMap, onUpdateTextField: () -> Unit) = intent {
+        onUpdateTextField()
         reduce {
             state.copy(
                 selectedSpotByMap = searchedSpotByMap,

--- a/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/UploadPlaceViewModel.kt
+++ b/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/UploadPlaceViewModel.kt
@@ -49,7 +49,7 @@ class UploadPlaceViewModel @Inject constructor(
             }
 
             viewModelScope.launch {
-                queryFlow
+                searchPlaceQueryFlow
                     .debounce(100)
                     .distinctUntilChanged()
                     .collect { query ->
@@ -83,6 +83,7 @@ class UploadPlaceViewModel @Inject constructor(
         }
 
     private val queryFlow = MutableStateFlow("")
+    private val searchPlaceQueryFlow = MutableStateFlow("")
 
     fun onSearchQueryChanged(query: String) = intent {
         queryFlow.value = query
@@ -96,11 +97,11 @@ class UploadPlaceViewModel @Inject constructor(
                 )
             else
                 state.copy(
-                    selectedSpotByMap = null,
+                    selectedSpotByMap = state.selectedSpotByMap?.takeIf { it.title == query },
                     showSearchedSpotsByMap = query.isNotBlank()
                 )
         }
-        queryFlow.value = query
+        searchPlaceQueryFlow.value = query
     }
 
     fun onSearchSpotByMapClicked(searchedSpotByMap: SearchedSpotByMap, onSuccess: () -> Unit) = intent {
@@ -219,6 +220,14 @@ class UploadPlaceViewModel @Inject constructor(
     fun onDismissExitUploadPlaceDialog() = intent {
         reduce {
             state.copy(showExitUploadPlaceDialog = false)
+        }
+    }
+
+    fun onHideSearchedPlaceList() = intent {
+        reduce {
+            state.copy(
+                showSearchedSpotsByMap = false
+            )
         }
     }
 

--- a/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/UploadPlaceViewModel.kt
+++ b/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/UploadPlaceViewModel.kt
@@ -12,6 +12,7 @@ import com.acon.acon.core.ui.base.BaseContainerHost
 import com.acon.acon.domain.repository.MapSearchRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -231,6 +232,24 @@ class UploadPlaceViewModel @Inject constructor(
         }
     }
 
+    fun onRequestUploadPlaceLimitPouUp() = intent {
+        reduce {
+            state.copy(
+                showUploadPlaceLimitPouUp = true
+            )
+        }
+
+        viewModelScope.launch {
+            delay(3500)
+            intent {
+                reduce {
+                    state.copy(showUploadPlaceLimitPouUp = false)
+                }
+            }
+
+        }
+    }
+
     fun onNavigateToBack() = intent {
         postSideEffect(UploadPlaceSideEffect.OnNavigateToBack)
     }
@@ -247,6 +266,7 @@ data class UploadPlaceUiState(
     val showExitUploadPlaceDialog: Boolean = false,
     val showRemoveUploadPlaceImageDialog: Boolean = false,
     val showUploadPlaceLimitDialog: Boolean = false,
+    val showUploadPlaceLimitPouUp: Boolean = false,
     val selectedSpotByMap: SearchedSpotByMap? = null,
     val searchedSpotsByMap: List<SearchedSpotByMap> = listOf(),
     val showSearchedSpotsByMap: Boolean = false,

--- a/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/UploadPlaceViewModel.kt
+++ b/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/UploadPlaceViewModel.kt
@@ -68,7 +68,15 @@ class UploadPlaceViewModel @Inject constructor(
                                         searchedSpotsByMap = it
                                     )
                                 }
-                            }.onFailure {  }
+                            }.onFailure {
+                                if (it.message?.contains("HTTP 429") == true) {
+                                    reduce {
+                                        state.copy(
+                                            showUploadPlaceLimitDialog = true
+                                        )
+                                    }
+                                }
+                            }
                         }
                     }
             }
@@ -213,6 +221,14 @@ class UploadPlaceViewModel @Inject constructor(
             state.copy(showExitUploadPlaceDialog = false)
         }
     }
+
+    fun onNavigateToBack() = intent {
+        postSideEffect(UploadPlaceSideEffect.OnNavigateToBack)
+    }
+
+    fun onClickReportPlace() = intent {
+        postSideEffect(UploadPlaceSideEffect.OnMoveToReportPlace)
+    }
 }
 
 @Immutable
@@ -221,6 +237,7 @@ data class UploadPlaceUiState(
     val isNextBtnEnabled: Boolean = false,
     val showExitUploadPlaceDialog: Boolean = false,
     val showRemoveUploadPlaceImageDialog: Boolean = false,
+    val showUploadPlaceLimitDialog: Boolean = false,
     val selectedSpotByMap: SearchedSpotByMap? = null,
     val searchedSpotsByMap: List<SearchedSpotByMap> = listOf(),
     val showSearchedSpotsByMap: Boolean = false,
@@ -236,4 +253,7 @@ data class UploadPlaceUiState(
     val currentStep: Int = 0
 )
 
-sealed interface UploadPlaceSideEffect
+sealed interface UploadPlaceSideEffect {
+    data object OnNavigateToBack : UploadPlaceSideEffect
+    data object OnMoveToReportPlace : UploadPlaceSideEffect
+}

--- a/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/composable/add/UploadPlaceScreen.kt
+++ b/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/composable/add/UploadPlaceScreen.kt
@@ -214,7 +214,8 @@ fun UploadPlaceScreen(
                             onDismissRemoveUploadPlaceImageDialog = viewModel::onDismissRemoveUploadPlaceImageDialog,
                             onAddSpotImageUri = viewModel::onAddImageUris,
                             onRemoveSpotImageUri = viewModel::onRemoveImageUri,
-                            onUpdateNextPageBtnEnabled = viewModel::updateNextBtnEnabled
+                            onUpdateNextPageBtnEnabled = viewModel::updateNextBtnEnabled,
+                            onRequestUploadPlaceLimitPouUp = viewModel::onRequestUploadPlaceLimitPouUp
                         )
                         6 -> UploadPlaceCompleteScreen()
                     }

--- a/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/composable/add/UploadPlaceScreen.kt
+++ b/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/composable/add/UploadPlaceScreen.kt
@@ -2,6 +2,7 @@ package com.acon.acon.feature.upload.screen.composable.add
 
 import android.content.Intent
 import android.net.Uri
+import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.SizeTransform
 import androidx.compose.animation.slideInVertically
@@ -61,7 +62,7 @@ private const val maxStepIndex = 6
 @Composable
 fun UploadPlaceScreen(
     modifier: Modifier = Modifier,
-    onNavigateBack: () -> Unit = {},
+    onNavigateHome: () -> Unit = {},
     viewModel: UploadPlaceViewModel = hiltViewModel()
 ) {
     val context = LocalContext.current
@@ -72,13 +73,17 @@ fun UploadPlaceScreen(
 
     val currentStep = state.currentStep
 
+    BackHandler {
+        viewModel.onRequestExitUploadPlaceDialog()
+    }
+
     viewModel.collectSideEffect {
         when(it) {
             UploadPlaceSideEffect.OnMoveToReportPlace -> {
                 val intent = Intent(Intent.ACTION_VIEW, Uri.parse(UrlConstants.ACON_INSTARGRAM))
                 context.startActivity(intent)
             }
-            UploadPlaceSideEffect.OnNavigateToBack -> onNavigateBack()
+            UploadPlaceSideEffect.OnNavigateToBack -> onNavigateHome()
         }
     }
 
@@ -104,7 +109,7 @@ fun UploadPlaceScreen(
                 viewModel.onDismissExitUploadPlaceDialog()
             },
             onAction2 = {
-                onNavigateBack()
+                viewModel.onNavigateToBack()
             },
             modifier = Modifier.width(dialogWidth)
         )
@@ -283,7 +288,7 @@ fun UploadPlaceScreen(
 private fun UploadPlaceScreenPreview() {
     AconTheme {
         UploadPlaceScreen(
-            onNavigateBack = {}
+            onNavigateHome = {}
         )
     }
 }

--- a/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/composable/add/UploadPlaceScreen.kt
+++ b/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/composable/add/UploadPlaceScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.acon.acon.core.designsystem.R
 import com.acon.acon.core.designsystem.component.button.v2.AconFilledTextButton
@@ -47,7 +48,6 @@ import com.acon.acon.feature.upload.screen.composable.add.place.UploadSelectPlac
 import com.acon.acon.feature.upload.screen.composable.add.price.UploadSelectPriceScreen
 import com.acon.acon.feature.upload.screen.composable.add.search.UploadPlaceSearchScreen
 import com.acon.acon.feature.upload.screen.composable.menu.UploadPlaceEnterMenuScreen
-import dev.chrisbanes.haze.hazeSource
 import org.orbitmvi.orbit.compose.collectAsState
 
 private const val maxStepIndex = 6
@@ -99,6 +99,7 @@ fun UploadPlaceScreen(
         Box(
             modifier = Modifier
                 .fillMaxWidth()
+                .zIndex(1f)
                 .defaultHazeEffect(
                     hazeState = LocalHazeState.current,
                     tintColor = AconTheme.color.GlassGray900,
@@ -141,7 +142,6 @@ fun UploadPlaceScreen(
             Column(
                 modifier = Modifier
                     .fillMaxSize()
-                    .hazeSource(LocalHazeState.current)
             ) {
                 AnimatedContent(
                     targetState = currentStep,

--- a/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/composable/add/UploadPlaceScreen.kt
+++ b/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/composable/add/UploadPlaceScreen.kt
@@ -1,5 +1,7 @@
 package com.acon.acon.feature.upload.screen.composable.add
 
+import android.content.Intent
+import android.net.Uri
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.SizeTransform
 import androidx.compose.animation.slideInVertically
@@ -26,6 +28,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.font.FontWeight
@@ -33,6 +36,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.acon.acon.core.common.UrlConstants
 import com.acon.acon.core.designsystem.R
 import com.acon.acon.core.designsystem.component.button.v2.AconFilledTextButton
 import com.acon.acon.core.designsystem.component.dialog.v2.AconTwoActionDialog
@@ -41,6 +45,7 @@ import com.acon.acon.core.designsystem.effect.LocalHazeState
 import com.acon.acon.core.designsystem.effect.defaultHazeEffect
 import com.acon.acon.core.designsystem.theme.AconTheme
 import com.acon.acon.core.ui.compose.getScreenWidth
+import com.acon.acon.feature.upload.screen.UploadPlaceSideEffect
 import com.acon.acon.feature.upload.screen.UploadPlaceViewModel
 import com.acon.acon.feature.upload.screen.composable.add.image.UploadPlaceImageScreen
 import com.acon.acon.feature.upload.screen.composable.add.place.UploadSelectPlaceDetailScreen
@@ -49,6 +54,7 @@ import com.acon.acon.feature.upload.screen.composable.add.price.UploadSelectPric
 import com.acon.acon.feature.upload.screen.composable.add.search.UploadPlaceSearchScreen
 import com.acon.acon.feature.upload.screen.composable.menu.UploadPlaceEnterMenuScreen
 import org.orbitmvi.orbit.compose.collectAsState
+import org.orbitmvi.orbit.compose.collectSideEffect
 
 private const val maxStepIndex = 6
 
@@ -58,12 +64,23 @@ fun UploadPlaceScreen(
     onNavigateBack: () -> Unit = {},
     viewModel: UploadPlaceViewModel = hiltViewModel()
 ) {
+    val context = LocalContext.current
     val state by viewModel.collectAsState()
 
     val screenWidthDp = getScreenWidth()
     val dialogWidth = (screenWidthDp * (260f / 360f))
 
     val currentStep = state.currentStep
+
+    viewModel.collectSideEffect {
+        when(it) {
+            UploadPlaceSideEffect.OnMoveToReportPlace -> {
+                val intent = Intent(Intent.ACTION_VIEW, Uri.parse(UrlConstants.ACON_INSTARGRAM))
+                context.startActivity(intent)
+            }
+            UploadPlaceSideEffect.OnNavigateToBack -> onNavigateBack()
+        }
+    }
 
     LaunchedEffect(Unit) {
         snapshotFlow { state.currentStep }
@@ -155,8 +172,11 @@ fun UploadPlaceScreen(
                     contentKey = { it }
                 ) { step ->
                     when(step) {
+
                         0 -> UploadPlaceSearchScreen(
                             state = state,
+                            onBackAction = viewModel::onNavigateToBack,
+                            onClickReportPlace = viewModel::onClickReportPlace,
                             onSearchedSpotClick = viewModel::onSearchSpotByMapClicked,
                             onSearchQueryOrSelectionChanged = viewModel::onSearchQueryOrSelectionChanged
                         )

--- a/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/composable/add/UploadPlaceScreen.kt
+++ b/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/composable/add/UploadPlaceScreen.kt
@@ -87,6 +87,7 @@ fun UploadPlaceScreen(
             .collect { currentStep ->
                 if (currentStep == 0) {
                     viewModel.onPreviousBtnDisabled()
+                    viewModel.updateNextBtnEnabled(state.selectedSpotByMap?.title?.isNotEmpty() == true)
                 } else {
                     viewModel.onPreviousBtnEnabled()
                 }
@@ -177,6 +178,7 @@ fun UploadPlaceScreen(
                             state = state,
                             onBackAction = viewModel::onNavigateToBack,
                             onClickReportPlace = viewModel::onClickReportPlace,
+                            onHideSearchedPlaceList = viewModel::onHideSearchedPlaceList,
                             onSearchedSpotClick = viewModel::onSearchSpotByMapClicked,
                             onSearchQueryOrSelectionChanged = viewModel::onSearchQueryOrSelectionChanged
                         )

--- a/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/composable/add/UploadPlaceScreen.kt
+++ b/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/composable/add/UploadPlaceScreen.kt
@@ -70,7 +70,6 @@ fun UploadPlaceScreen(
             .collect { currentStep ->
                 if (currentStep == 0) {
                     viewModel.onPreviousBtnDisabled()
-                    viewModel.updateNextBtnEnabled(true) // TODO - 임시조건 (검색 구현 후 삭제)
                 } else {
                     viewModel.onPreviousBtnEnabled()
                 }
@@ -156,7 +155,11 @@ fun UploadPlaceScreen(
                     contentKey = { it }
                 ) { step ->
                     when(step) {
-                        0 -> UploadPlaceSearchScreen()
+                        0 -> UploadPlaceSearchScreen(
+                            state = state,
+                            onSearchedSpotClick = viewModel::onSearchSpotByMapClicked,
+                            onSearchQueryOrSelectionChanged = viewModel::onSearchQueryOrSelectionChanged
+                        )
                         1 -> UploadSelectPlaceScreen(
                             state = state,
                             onSelectSpotType = viewModel::updateSpotType,

--- a/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/composable/add/image/UploadPlaceImageScreen.kt
+++ b/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/composable/add/image/UploadPlaceImageScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import com.acon.acon.core.designsystem.R
 import com.acon.acon.core.designsystem.component.dialog.v2.AconTwoActionDialog
+import com.acon.acon.core.designsystem.component.popup.CustomToast
 import com.acon.acon.core.designsystem.effect.LocalHazeState
 import com.acon.acon.core.designsystem.effect.defaultHazeEffect
 import com.acon.acon.core.designsystem.noRippleClickable
@@ -56,7 +57,8 @@ internal fun UploadPlaceImageScreen(
     onDismissRemoveUploadPlaceImageDialog: () -> Unit,
     onAddSpotImageUri:(uris: List<Uri>) -> Unit,
     onRemoveSpotImageUri:(uri: Uri) -> Unit,
-    onUpdateNextPageBtnEnabled: (Boolean) -> Unit
+    onUpdateNextPageBtnEnabled: (Boolean) -> Unit,
+    onRequestUploadPlaceLimitPouUp: () -> Unit
 ) {
     val selectedUris = state.selectedImageUris ?: emptyList()
 
@@ -71,7 +73,14 @@ internal fun UploadPlaceImageScreen(
         val currentSize = selectedUris.size
         val canAddCount = maxImageCount - currentSize
         val toAdd = uris.take(canAddCount)
-        onAddSpotImageUri(toAdd)
+
+        if (toAdd.isNotEmpty()) {
+            onAddSpotImageUri(toAdd)
+        }
+
+        if (uris.size > canAddCount) {
+            onRequestUploadPlaceLimitPouUp()
+        }
     }
 
     val peekAmount = 24.dp
@@ -144,102 +153,109 @@ internal fun UploadPlaceImageScreen(
         )
 
         Spacer(Modifier.height(32.dp))
-        if (selectedUris.isEmpty()) {
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(imageBoxHeight)
-                    .clip(RoundedCornerShape(10.dp))
-                    .background(AconTheme.color.GlassWhiteDisabled)
-                    .aspectRatio(1f)
-                    .noRippleClickable {
-                        galleryLauncher.launch(
-                            PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
-                        )
-                    }
-            ) {
-                Icon(
-                    imageVector = ImageVector.vectorResource(R.drawable.ic_plus),
-                    contentDescription = stringResource(R.string.content_description_upload_place_image),
-                    tint = AconTheme.color.Gray50,
+        Box {
+            if (selectedUris.isEmpty()) {
+                Box(
                     modifier = Modifier
-                        .align(Alignment.Center)
-                )
-            }
-        } else {
-            HorizontalPager(
-                state = pagerState,
-                contentPadding = PaddingValues(horizontal = peekAmount),
-                pageSpacing = 8.dp,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(imageBoxHeight)
-            ) { page ->
-                if (page < selectedUris.size) {
-                    Box(
+                        .fillMaxWidth()
+                        .height(imageBoxHeight)
+                        .clip(RoundedCornerShape(10.dp))
+                        .background(AconTheme.color.GlassWhiteDisabled)
+                        .aspectRatio(1f)
+                        .noRippleClickable {
+                            galleryLauncher.launch(
+                                PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
+                            )
+                        }
+                ) {
+                    Icon(
+                        imageVector = ImageVector.vectorResource(R.drawable.ic_plus),
+                        contentDescription = stringResource(R.string.content_description_upload_place_image),
+                        tint = AconTheme.color.Gray50,
                         modifier = Modifier
-                            .fillMaxSize()
-                            .clip(RoundedCornerShape(10.dp))
-                            .aspectRatio(1f)
-                    ) {
-                        AsyncImage(
-                            model = selectedUris[page],
-                            contentDescription = stringResource(R.string.content_description_select_upload_place_image),
-                            modifier = Modifier.fillMaxSize()
-                                .hazeSource(LocalHazeState.current)
-                            ,
-                            contentScale = ContentScale.Crop
-                        )
-
+                            .align(Alignment.Center)
+                    )
+                }
+            } else {
+                HorizontalPager(
+                    state = pagerState,
+                    contentPadding = PaddingValues(horizontal = peekAmount),
+                    pageSpacing = 8.dp,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(imageBoxHeight)
+                ) { page ->
+                    if (page < selectedUris.size) {
                         Box(
                             modifier = Modifier
-                                .align(Alignment.BottomEnd)
-                                .padding(end = 16.dp, bottom = 16.dp)
-                                .clip(CircleShape)
-                                .border(
-                                    width = 1.dp,
-                                    color = AconTheme.color.GlassWhiteSelected,
-                                    shape = CircleShape
+                                .fillMaxSize()
+                                .clip(RoundedCornerShape(10.dp))
+                                .aspectRatio(1f)
+                        ) {
+                            AsyncImage(
+                                model = selectedUris[page],
+                                contentDescription = stringResource(R.string.content_description_select_upload_place_image),
+                                modifier = Modifier.fillMaxSize()
+                                    .hazeSource(LocalHazeState.current),
+                                contentScale = ContentScale.Crop
+                            )
+
+                            Box(
+                                modifier = Modifier
+                                    .align(Alignment.BottomEnd)
+                                    .padding(end = 16.dp, bottom = 16.dp)
+                                    .clip(CircleShape)
+                                    .border(
+                                        width = 1.dp,
+                                        color = AconTheme.color.GlassWhiteSelected,
+                                        shape = CircleShape
+                                    )
+                                    .defaultHazeEffect(
+                                        hazeState = LocalHazeState.current,
+                                        tintColor = AconTheme.color.GlassWhiteLight
+                                    )
+                            ) {
+                                Icon(
+                                    imageVector = ImageVector.vectorResource(R.drawable.ic_delete),
+                                    contentDescription = stringResource(R.string.content_description_delete_uploaded_place_image),
+                                    tint = AconTheme.color.Action,
+                                    modifier = Modifier
+                                        .padding(10.dp)
+                                        .noRippleClickable {
+                                            onRequestRemoveUploadPlaceImageDialog(selectedUris[page])
+                                        }
                                 )
-                                .defaultHazeEffect(
-                                    hazeState = LocalHazeState.current,
-                                    tintColor = AconTheme.color.GlassWhiteLight
-                                )
+                            }
+                        }
+                    } else {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .clip(RoundedCornerShape(10.dp))
+                                .background(AconTheme.color.GlassWhiteDisabled)
+                                .aspectRatio(1f)
+                                .noRippleClickable {
+                                    galleryLauncher.launch(
+                                        PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
+                                    )
+                                }
                         ) {
                             Icon(
-                                imageVector = ImageVector.vectorResource(R.drawable.ic_delete),
-                                contentDescription = stringResource(R.string.content_description_delete_uploaded_place_image),
-                                tint = AconTheme.color.Action,
+                                imageVector = ImageVector.vectorResource(R.drawable.ic_plus),
+                                contentDescription = stringResource(R.string.content_description_upload_place_image),
+                                tint = AconTheme.color.Gray50,
                                 modifier = Modifier
-                                    .padding(10.dp)
-                                    .noRippleClickable {
-                                        onRequestRemoveUploadPlaceImageDialog(selectedUris[page])
-                                    }
+                                    .align(Alignment.Center)
                             )
                         }
                     }
-                } else {
-                    Box(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .clip(RoundedCornerShape(10.dp))
-                            .background(AconTheme.color.GlassWhiteDisabled)
-                            .aspectRatio(1f)
-                            .noRippleClickable {
-                                galleryLauncher.launch(
-                                    PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
-                                )
-                            }
-                    ) {
-                        Icon(
-                            imageVector = ImageVector.vectorResource(R.drawable.ic_plus),
-                            contentDescription = stringResource(R.string.content_description_upload_place_image),
-                            tint = AconTheme.color.Gray50,
-                            modifier = Modifier
-                                .align(Alignment.Center)
-                        )
-                    }
                 }
+            }
+
+            if (state.showUploadPlaceLimitPouUp) {
+                CustomToast(
+                    message = stringResource(R.string.upload_place_image_limit_toast)
+                )
             }
         }
     }
@@ -255,7 +271,8 @@ private fun UploadPlaceImageScreenPreview() {
             onDismissRemoveUploadPlaceImageDialog = {},
             onAddSpotImageUri = {},
             onRemoveSpotImageUri = {},
-            onUpdateNextPageBtnEnabled = {}
+            onUpdateNextPageBtnEnabled = {},
+            onRequestUploadPlaceLimitPouUp = {}
         )
     }
 }

--- a/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/composable/add/image/UploadPlaceImageScreen.kt
+++ b/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/composable/add/image/UploadPlaceImageScreen.kt
@@ -5,6 +5,7 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -17,6 +18,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
@@ -35,12 +37,14 @@ import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import com.acon.acon.core.designsystem.R
 import com.acon.acon.core.designsystem.component.dialog.v2.AconTwoActionDialog
-import com.acon.acon.core.designsystem.effect.imageGradientBottomLayer
+import com.acon.acon.core.designsystem.effect.LocalHazeState
+import com.acon.acon.core.designsystem.effect.defaultHazeEffect
 import com.acon.acon.core.designsystem.noRippleClickable
 import com.acon.acon.core.designsystem.theme.AconTheme
 import com.acon.acon.core.ui.compose.getScreenHeight
 import com.acon.acon.core.ui.compose.getScreenWidth
 import com.acon.acon.feature.upload.screen.UploadPlaceUiState
+import dev.chrisbanes.haze.hazeSource
 import kotlinx.coroutines.flow.distinctUntilChanged
 
 private const val maxImageCount = 10
@@ -181,27 +185,38 @@ internal fun UploadPlaceImageScreen(
                         AsyncImage(
                             model = selectedUris[page],
                             contentDescription = stringResource(R.string.content_description_select_upload_place_image),
-                            modifier = Modifier.fillMaxSize(),
+                            modifier = Modifier.fillMaxSize()
+                                .hazeSource(LocalHazeState.current)
+                            ,
                             contentScale = ContentScale.Crop
-                        )
-
-                        Icon(
-                            imageVector = ImageVector.vectorResource(R.drawable.ic_delete),
-                            contentDescription = stringResource(R.string.content_description_delete_uploaded_place_image),
-                            tint = AconTheme.color.Action,
-                            modifier = Modifier
-                                .align(Alignment.BottomEnd)
-                                .padding(end = 16.dp, bottom = 16.dp)
-                                .noRippleClickable {
-                                    onRequestRemoveUploadPlaceImageDialog(selectedUris[page])
-                                }
                         )
 
                         Box(
                             modifier = Modifier
-                                .fillMaxSize()
-                                .imageGradientBottomLayer()
-                        )
+                                .align(Alignment.BottomEnd)
+                                .padding(end = 16.dp, bottom = 16.dp)
+                                .clip(CircleShape)
+                                .border(
+                                    width = 1.dp,
+                                    color = AconTheme.color.GlassWhiteSelected,
+                                    shape = CircleShape
+                                )
+                                .defaultHazeEffect(
+                                    hazeState = LocalHazeState.current,
+                                    tintColor = AconTheme.color.GlassWhiteLight
+                                )
+                        ) {
+                            Icon(
+                                imageVector = ImageVector.vectorResource(R.drawable.ic_delete),
+                                contentDescription = stringResource(R.string.content_description_delete_uploaded_place_image),
+                                tint = AconTheme.color.Action,
+                                modifier = Modifier
+                                    .padding(10.dp)
+                                    .noRippleClickable {
+                                        onRequestRemoveUploadPlaceImageDialog(selectedUris[page])
+                                    }
+                            )
+                        }
                     }
                 } else {
                     Box(

--- a/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/composable/add/place/UploadSelectPlaceDetailScreen.kt
+++ b/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/composable/add/place/UploadSelectPlaceDetailScreen.kt
@@ -128,7 +128,7 @@ internal fun UploadSelectPlaceDetailScreen(
                     color = AconTheme.color.White
                 )
 
-                Spacer(Modifier.height(100.dp))
+                Spacer(Modifier.height(32.dp))
                 Column(
                     modifier = Modifier
                         .fillMaxWidth()

--- a/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/composable/add/search/UploadPlaceSearchScreen.kt
+++ b/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/composable/add/search/UploadPlaceSearchScreen.kt
@@ -26,7 +26,9 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import com.acon.acon.core.designsystem.R
 import com.acon.acon.core.designsystem.component.textfield.v2.AconSearchTextField
+import com.acon.acon.core.designsystem.effect.LocalHazeState
 import com.acon.acon.core.designsystem.theme.AconTheme
+import dev.chrisbanes.haze.hazeSource
 
 @Composable
 internal fun UploadPlaceSearchScreen(
@@ -50,6 +52,7 @@ internal fun UploadPlaceSearchScreen(
     ) {
         Column(
             modifier = Modifier
+                .hazeSource(LocalHazeState.current)
                 .onGloballyPositioned { coordinates ->
                     offsetY = coordinates.size.height
                 }

--- a/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/composable/add/search/UploadPlaceSearchScreen.kt
+++ b/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/composable/add/search/UploadPlaceSearchScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -237,7 +238,7 @@ private fun SearchedSpots(
 
             items(
                 items = searchedSpotsByMap,
-                key = {  it.address + it.title },
+                key = { it.id },
             ) {
                 SearchedSpotItem(
                     modifier = Modifier
@@ -258,18 +259,28 @@ private fun SearchedSpotItem(
     searchedSpotByMap: SearchedSpotByMap,
     modifier: Modifier = Modifier
 ) {
-    Column(
-        modifier = modifier
+    Row(
+        modifier = modifier,
     ) {
-        Text(
-            text = searchedSpotByMap.title,
-            style = AconTheme.typography.Title4,
-            color = AconTheme.color.White
-        )
+        Column(
+            modifier = Modifier.weight(1f)
+        ) {
+            Text(
+                text = searchedSpotByMap.title,
+                style = AconTheme.typography.Title4,
+                color = AconTheme.color.White
+            )
 
-        Spacer(Modifier.height(4.dp))
+            Spacer(Modifier.height(4.dp))
+            Text(
+                text = searchedSpotByMap.roadAddress.takeIf { it.isNotEmpty() } ?: searchedSpotByMap.address,
+                style = AconTheme.typography.Body1,
+                color = AconTheme.color.Gray500
+            )
+        }
+
         Text(
-            text = searchedSpotByMap.address,
+            text = searchedSpotByMap.category,
             style = AconTheme.typography.Body1,
             color = AconTheme.color.Gray500
         )

--- a/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/composable/add/search/UploadPlaceSearchScreen.kt
+++ b/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/composable/add/search/UploadPlaceSearchScreen.kt
@@ -69,7 +69,7 @@ internal fun UploadPlaceSearchScreen(
     onBackAction: () -> Unit,
     onClickReportPlace: () -> Unit,
     onHideSearchedPlaceList: () -> Unit,
-    onSearchedSpotClick: (SearchedSpotByMap, onSuccess: () -> Unit) -> Unit,
+    onSearchedSpotClick: (SearchedSpotByMap, onUpdateTextField: () -> Unit) -> Unit,
     onSearchQueryOrSelectionChanged: (String, Boolean) -> Unit
 ) {
     val lifecycleOwner = LocalLifecycleOwner.current

--- a/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/composable/add/search/UploadPlaceSearchScreen.kt
+++ b/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/composable/add/search/UploadPlaceSearchScreen.kt
@@ -1,6 +1,9 @@
 package com.acon.acon.feature.upload.screen.composable.add.search
 
+import androidx.compose.animation.core.animateIntAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -8,18 +11,33 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.IntOffset
@@ -27,19 +45,47 @@ import androidx.compose.ui.unit.dp
 import com.acon.acon.core.designsystem.R
 import com.acon.acon.core.designsystem.component.textfield.v2.AconSearchTextField
 import com.acon.acon.core.designsystem.effect.LocalHazeState
+import com.acon.acon.core.designsystem.noRippleClickable
 import com.acon.acon.core.designsystem.theme.AconTheme
+import com.acon.acon.core.model.model.upload.SearchedSpotByMap
+import com.acon.acon.feature.upload.screen.UploadPlaceUiState
 import dev.chrisbanes.haze.hazeSource
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
 
 @Composable
 internal fun UploadPlaceSearchScreen(
-
+    state: UploadPlaceUiState,
+    onSearchedSpotClick: (SearchedSpotByMap, onSuccess: () -> Unit) -> Unit,
+    onSearchQueryOrSelectionChanged: (String, Boolean) -> Unit
 ) {
-    //TODO - 아래 offsetY 관련 코드는 모두 임시용 - 추후 애니메이션, 글래스모피즘 적용
+    val focusManager = LocalFocusManager.current
+    val keyboardController = LocalSoftwareKeyboardController.current
+
     var offsetY by remember { mutableIntStateOf(0) }
-    var isTextFieldFocused by remember { mutableStateOf(false) } // TODO - 임시 변수
+    var isTextFieldFocused by remember { mutableStateOf(false) }
 
     var query by rememberSaveable(stateSaver = TextFieldValue.Saver) { mutableStateOf(TextFieldValue("")) }
     var isSelection by remember { mutableStateOf(false) }
+
+    val offsetYAnimated by animateIntAsState(
+        targetValue = if (isTextFieldFocused) -offsetY else 0,
+        animationSpec = tween(durationMillis = 300)
+    )
+
+    LaunchedEffect(Unit) {
+        snapshotFlow { query }.collect {
+            onSearchQueryOrSelectionChanged(it.text, isSelection)
+        }
+    }
+
+    LaunchedEffect(state.showSearchedSpotsByMap) {
+        if(!state.showSearchedSpotsByMap) {
+            keyboardController?.hide()
+            focusManager.clearFocus()
+            isTextFieldFocused = false
+        }
+    }
 
     Column(
         modifier = Modifier
@@ -47,7 +93,7 @@ internal fun UploadPlaceSearchScreen(
             .background(AconTheme.color.Gray900)
             .padding(horizontal = 16.dp)
             .offset {
-                IntOffset(x = 0, y = if (isTextFieldFocused) -offsetY else 0)
+                IntOffset(x = 0, y = offsetYAnimated)
             }
     ) {
         Column(
@@ -74,18 +120,125 @@ internal fun UploadPlaceSearchScreen(
             Spacer(Modifier.height(20.dp))
         }
 
-        AconSearchTextField(
-            value = query,
-            onValueChange = {
-                query = it
-                isSelection = false
-            },
-            placeholder = stringResource(R.string.upload_place_search_placeholder),
-            modifier = Modifier
-                .fillMaxWidth()
-                .onFocusChanged { focusState ->
-                    isTextFieldFocused = focusState.isFocused
+        Column {
+            AconSearchTextField(
+                value = query,
+                onValueChange = {
+                    query = it
+                    isSelection = false
+                },
+                placeholder = stringResource(R.string.upload_place_search_placeholder),
+                keyboardOptions = KeyboardOptions(
+                    imeAction = ImeAction.Done,
+                    keyboardType = KeyboardType.Text
+                ),
+                keyboardActions = KeyboardActions(
+                    onDone = {
+                        keyboardController?.hide()
+                        focusManager.clearFocus()
+                        isTextFieldFocused = false
+                    }
+                ),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .onFocusChanged { focusState ->
+                        isTextFieldFocused = focusState.isFocused
+                    }
+            )
+            Box {
+                if (state.showSearchedSpotsByMap) {
+                    SearchedSpots(
+                        searchedSpotsByMap = state.searchedSpotsByMap.toImmutableList(),
+                        onItemClick = {
+                            onSearchedSpotClick(it) {
+                                isSelection = true
+                                query = TextFieldValue(
+                                    text = it.title,
+                                    selection = TextRange(it.title.length)
+                                )
+                            }
+                        },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = 10.dp)
+                            .height(300.dp)
+                            .clip(RoundedCornerShape(10.dp))
+                            .background(AconTheme.color.GlassWhiteLight)
+                    )
                 }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SearchedSpots(
+    searchedSpotsByMap: ImmutableList<SearchedSpotByMap>,
+    onItemClick: (SearchedSpotByMap) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier) {
+        LazyColumn(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            if (searchedSpotsByMap.isEmpty()) {
+                item {
+                    Text(
+                        text = stringResource(R.string.upload_place_no_search_result),
+                        style = AconTheme.typography.Body1,
+                        color = AconTheme.color.White,
+                        fontWeight = FontWeight.SemiBold,
+                        modifier = Modifier.padding(top = 20.dp)
+                    )
+
+                    Text(
+                        text = stringResource(R.string.upload_place_no_search_try_again),
+                        style = AconTheme.typography.Body1,
+                        color = AconTheme.color.White,
+                        fontWeight = FontWeight.Normal,
+                        modifier = Modifier.padding(top = 40.dp)
+                    )
+                }
+            }
+
+            items(
+                items = searchedSpotsByMap,
+                key = {  it.address + it.title },
+            ) {
+                SearchedSpotItem(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 12.dp)
+                        .noRippleClickable {
+                            onItemClick(it)
+                        },
+                    searchedSpotByMap = it
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SearchedSpotItem(
+    searchedSpotByMap: SearchedSpotByMap,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+    ) {
+        Text(
+            text = searchedSpotByMap.title,
+            style = AconTheme.typography.Title4,
+            color = AconTheme.color.White
+        )
+
+        Spacer(Modifier.height(4.dp))
+        Text(
+            text = searchedSpotByMap.address,
+            style = AconTheme.typography.Body1,
+            color = AconTheme.color.Gray500
         )
     }
 }
@@ -94,6 +247,10 @@ internal fun UploadPlaceSearchScreen(
 @Composable
 private fun UploadPlaceSearchScreenPreview() {
     AconTheme {
-        UploadPlaceSearchScreen()
+        UploadPlaceSearchScreen(
+            state = UploadPlaceUiState(),
+            onSearchedSpotClick = { _, _ -> },
+            onSearchQueryOrSelectionChanged = { _, _ -> }
+        )
     }
 }

--- a/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/composable/add/search/UploadPlaceSearchScreen.kt
+++ b/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/composable/add/search/UploadPlaceSearchScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -39,15 +40,18 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import com.acon.acon.core.designsystem.R
+import com.acon.acon.core.designsystem.component.dialog.v2.AconTwoActionDialog
 import com.acon.acon.core.designsystem.component.textfield.v2.AconSearchTextField
 import com.acon.acon.core.designsystem.effect.LocalHazeState
 import com.acon.acon.core.designsystem.noRippleClickable
 import com.acon.acon.core.designsystem.theme.AconTheme
 import com.acon.acon.core.model.model.upload.SearchedSpotByMap
+import com.acon.acon.core.ui.compose.getScreenWidth
 import com.acon.acon.feature.upload.screen.UploadPlaceUiState
 import dev.chrisbanes.haze.hazeSource
 import kotlinx.collections.immutable.ImmutableList
@@ -56,9 +60,14 @@ import kotlinx.collections.immutable.toImmutableList
 @Composable
 internal fun UploadPlaceSearchScreen(
     state: UploadPlaceUiState,
+    onBackAction: () -> Unit,
+    onClickReportPlace: () -> Unit,
     onSearchedSpotClick: (SearchedSpotByMap, onSuccess: () -> Unit) -> Unit,
     onSearchQueryOrSelectionChanged: (String, Boolean) -> Unit
 ) {
+    val screenWidthDp = getScreenWidth()
+    val dialogWidth = (screenWidthDp * (260f / 360f))
+
     val focusManager = LocalFocusManager.current
     val keyboardController = LocalSoftwareKeyboardController.current
 
@@ -84,6 +93,30 @@ internal fun UploadPlaceSearchScreen(
             keyboardController?.hide()
             focusManager.clearFocus()
             isTextFieldFocused = false
+        }
+    }
+
+    if(state.showUploadPlaceLimitDialog) {
+        AconTwoActionDialog(
+            title = stringResource(R.string.upload_place_limit_dialog_title),
+            action1 = stringResource(R.string.end),
+            action2 = stringResource(R.string.report),
+            onDismissRequest = {},
+            onAction1 = {
+                onBackAction()
+            },
+            onAction2 = {
+                onClickReportPlace()
+            },
+            modifier = Modifier.width(dialogWidth)
+        ) {
+            Text(
+                text = stringResource(R.string.upload_place_limit_dialog_content),
+                color = AconTheme.color.Gray200,
+                style = AconTheme.typography.Body1,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.padding(bottom = 22.dp)
+            )
         }
     }
 
@@ -249,6 +282,8 @@ private fun UploadPlaceSearchScreenPreview() {
     AconTheme {
         UploadPlaceSearchScreen(
             state = UploadPlaceUiState(),
+            onBackAction = { },
+            onClickReportPlace = {},
             onSearchedSpotClick = { _, _ -> },
             onSearchQueryOrSelectionChanged = { _, _ -> }
         )

--- a/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/composable/menu/UploadPlaceEnterMenuScreen.kt
+++ b/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/composable/menu/UploadPlaceEnterMenuScreen.kt
@@ -82,9 +82,11 @@ internal fun UploadPlaceEnterMenuScreen(
         Spacer(Modifier.height(32.dp))
         AconOutlinedSearchTextField(
             value = query,
-            onValueChange = {
-                query = it
-                isSelection = false
+            onValueChange = { newValue ->
+                if (newValue.text.length <= 20) {
+                    query = newValue
+                    isSelection = false
+                }
             },
             keyboardOptions = KeyboardOptions(
                 imeAction = ImeAction.Done,

--- a/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/composable/menu/UploadPlaceEnterMenuScreen.kt
+++ b/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/composable/menu/UploadPlaceEnterMenuScreen.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -22,6 +24,8 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -82,6 +86,16 @@ internal fun UploadPlaceEnterMenuScreen(
                 query = it
                 isSelection = false
             },
+            keyboardOptions = KeyboardOptions(
+                imeAction = ImeAction.Done,
+                keyboardType = KeyboardType.Text
+            ),
+            keyboardActions = KeyboardActions(
+                onDone = {
+                    keyboardController?.hide()
+                    focusManager.clearFocus()
+                }
+            ),
             placeholder = stringResource(R.string.upload_place_enter_menu_placeholder),
             modifier = Modifier.fillMaxWidth()
         )

--- a/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/composable/type/TypeExtensions.kt
+++ b/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/composable/type/TypeExtensions.kt
@@ -38,7 +38,7 @@ internal fun RestaurantFilterType.RestaurantType.getNameResId(): Int {
 
 internal fun CafeOptionType.getNameResId(): Int {
     return when(this) {
-        CafeOptionType.GOOD_FOR_WORK -> R.string.upload_place_select_cafe_option_1
-        CafeOptionType.NOT_GOOD_FOR_WORK -> R.string.upload_place_select_cafe_option_2
+        CafeOptionType.GOOD_FOR_WORK -> R.string.upload_place_select_cafe_option1
+        CafeOptionType.NOT_GOOD_FOR_WORK -> R.string.upload_place_select_cafe_option2
     }
 }


### PR DESCRIPTION
## *🧨 Issue*
- closed #234

## *💻 Work Description*
- 장소 검색 텍스트필드 클릭 시, 위로 화면 스크롤 됨 + 탑바에 의해 글래스모피즘 효과 적용
- 장소 검색 UI 수정 (상세히 구현)
- 네이버 장소 검색 API 구현 및 연결

## *📸 Screenshot*
https://github.com/user-attachments/assets/1f887776-049a-4cef-ab57-3e2a0d6ee1af

## *💭 To Reviewers*
- 네이버에서 결과를 반환 해줄 때 제목(장소명)에 html 태그를 섞어줘서 이거 때문에 이름이 이상하게 나오는 경우가 존재합니다.
  - reopsitoryImpl 부분에 조치를 해두긴했는데 가끔식 문제가 있는 경우가 여전히 있네요.

- 다음 버튼이 활성화되는 기준은 장소를 선택했을 때(단순 입력 X), 비활성화되는 기준은 장소 검색 텍스트필드가 empty일 때 입니다.