### PR TITLE
[Feat/#240] 글자 애니메이션 적용, QA 반영

### DIFF
--- a/core/designsystem/src/main/java/com/acon/acon/core/designsystem/animation/SlideUpAnimation.kt
+++ b/core/designsystem/src/main/java/com/acon/acon/core/designsystem/animation/SlideUpAnimation.kt
@@ -39,8 +39,12 @@ fun Modifier.slideUpAnimation(
         when (order) {
             1 -> delay
             2 -> delay + titleDelay
-            3 -> if (hasCaption) delay + titleDelay * 2 else delay
-            4 -> delay + contentDelay + titleDelay * (if (hasCaption) 2 else 1)
+            3 -> if (hasCaption) delay + titleDelay * 2 else 0
+            4 -> if (hasCaption) {
+                delay + titleDelay * 2 + contentDelay
+            } else {
+                delay + titleDelay + contentDelay
+            }
             else -> delay
         }
     }

--- a/core/designsystem/src/main/java/com/acon/acon/core/designsystem/animation/SlideUpAnimation.kt
+++ b/core/designsystem/src/main/java/com/acon/acon/core/designsystem/animation/SlideUpAnimation.kt
@@ -1,0 +1,82 @@
+package com.acon.acon.core.designsystem.animation
+
+import android.annotation.SuppressLint
+import androidx.compose.animation.core.Easing
+import androidx.compose.animation.core.LinearOutSlowInEasing
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.offset
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.acon.acon.core.designsystem.R
+import kotlinx.coroutines.delay
+
+@SuppressLint("UseOfNonLambdaOffsetOverload")
+@Composable
+fun Modifier.slideUpAnimation(
+    order: Int = 1,
+    delay: Int = 0,
+    duration: Int = 500,
+    easing: Easing = LinearOutSlowInEasing,
+    yOffset: Dp = 100.dp,
+    titleDelay: Int = 300,
+    contentDelay: Int = 600,
+    hasCaption: Boolean = false,
+    onAnimationEnded: () -> Unit = {}
+): Modifier = composed {
+    val animationDelay = remember(order, hasCaption) {
+        when (order) {
+            1 -> delay
+            2 -> delay + titleDelay
+            3 -> if (hasCaption) delay + titleDelay * 2 else delay
+            4 -> delay + contentDelay + titleDelay * (if (hasCaption) 2 else 1)
+            else -> delay
+        }
+    }
+
+    var visible by remember { mutableStateOf(false) }
+
+    LaunchedEffect(Unit) {
+        delay(animationDelay.toLong())
+        visible = true
+    }
+
+    val offsetY by animateDpAsState(
+        targetValue = if (visible) 0.dp else yOffset,
+        animationSpec = tween(
+            durationMillis = duration,
+            easing = easing
+        ),
+        label = stringResource(R.string.slide_up_offset)
+    )
+
+    val alpha by animateFloatAsState(
+        targetValue = if (visible) 1f else 0f,
+        animationSpec = tween(
+            durationMillis = duration,
+            easing = easing
+        ),
+        label = stringResource(R.string.slide_up_alpha)
+    )
+
+    LaunchedEffect(offsetY) {
+        if (offsetY == 0.dp) {
+            onAnimationEnded()
+        }
+    }
+
+    Modifier
+        .offset(y = offsetY)
+        .alpha(alpha)
+}

--- a/core/designsystem/src/main/java/com/acon/acon/core/designsystem/component/dialog/v2/AconTwoActionDialog.kt
+++ b/core/designsystem/src/main/java/com/acon/acon/core/designsystem/component/dialog/v2/AconTwoActionDialog.kt
@@ -34,6 +34,7 @@ fun AconTwoActionDialog(
     onAction1: () -> Unit,
     onAction2: () -> Unit,
     onDismissRequest: () -> Unit,
+    isTextAlign: Boolean = false,
     action1Color: Color = AconTheme.color.White,
     action2Color: Color = AconTheme.color.Action,
     modifier: Modifier = Modifier,
@@ -65,6 +66,7 @@ fun AconTwoActionDialog(
                     style = AconTheme.typography.Title4,
                     fontWeight = FontWeight.SemiBold,
                     color = AconTheme.color.White,
+                    textAlign = if (isTextAlign) TextAlign.Center else TextAlign.Unspecified,
                     modifier = Modifier
                         .padding(top = 24.dp, bottom = 22.dp)
                         .padding(horizontal = 16.dp)

--- a/core/designsystem/src/main/res/values/strings.xml
+++ b/core/designsystem/src/main/res/values/strings.xml
@@ -12,6 +12,7 @@
     <string name="select">선택</string>
     <string name="submit">제출하기</string>
     <string name="end">끝내기</string>
+    <string name="quit">그만두기</string>
     <string name="report">제보하기</string>
     <string name="continue_writing">계속 작성</string>
     <string name="next">다음</string>
@@ -216,7 +217,7 @@
 
     <!-- Upload Place -->
     <string name="upload_process_step_transition">upload_process_step_transition</string>
-    <string name="upload_place_exit">등록을 취소하시겠습니까?</string>
+    <string name="upload_place_exit">여기서 그만두면\n작성중인 내용이 사라져요</string>
     <string name="upload_place_topbar">장소 등록</string>
     <string name="required_field">필수 입력</string>
     <string name="optional_field">선택 입력</string>

--- a/core/designsystem/src/main/res/values/strings.xml
+++ b/core/designsystem/src/main/res/values/strings.xml
@@ -31,6 +31,10 @@
     <string name="do_next">다음에 하기</string>
     <string name="go_home">홈으로 가기</string>
 
+    <!-- label -->
+    <string name="slide_up_offset">slide_up_offset</string>
+    <string name="slide_up_alpha">slide_up_alpha</string>
+
     <!-- Etc -->
     <string name="restart">마무리 하기</string>
     <string name="update">업데이트</string>

--- a/core/model/src/main/java/com/acon/acon/core/model/type/FeatureType.kt
+++ b/core/model/src/main/java/com/acon/acon/core/model/type/FeatureType.kt
@@ -29,7 +29,7 @@ sealed interface RestaurantFeatureType : FeatureType {
 sealed interface CafeFeatureType : FeatureType {
 
     enum class CafeType: FeatureType {
-        GOOD_FOR_WORK,
+        WORK_FRIENDLY,
         NOT_GOOD_FOR_WORK;
     }
 }

--- a/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/UploadPlaceViewModel.kt
+++ b/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/UploadPlaceViewModel.kt
@@ -154,11 +154,7 @@ class UploadPlaceViewModel @Inject constructor(
     }
 
     fun updateCafeOptionType(cafeOption: CafeFeatureType.CafeType) = intent {
-        if(cafeOption == CafeFeatureType.CafeType.NOT_GOOD_FOR_WORK) {
-            reduce { state.copy(selectedCafeOption = null) }
-        } else {
-            reduce { state.copy(selectedCafeOption = cafeOption) }
-        }
+        reduce { state.copy(selectedCafeOption = cafeOption) }
     }
 
     fun updatePriceOptionType(priceOption: PriceFeatureType.PriceOptionType) = intent {
@@ -295,12 +291,21 @@ class UploadPlaceViewModel @Inject constructor(
         when(state.selectedRestaurantTypes.isEmpty()) {
             true -> {
                 state.selectedCafeOption?.let { cafeOption ->
-                    featureRequests.add(
-                        Feature(
-                            category = CategoryType.CAFE_FEATURE,
-                            optionList = listOf(cafeOption)
+                    if (cafeOption == CafeFeatureType.CafeType.NOT_GOOD_FOR_WORK) {
+                        featureRequests.add(
+                            Feature(
+                                category = CategoryType.CAFE_FEATURE,
+                                optionList = emptyList()
+                            )
                         )
-                    )
+                    } else {
+                        featureRequests.add(
+                            Feature(
+                                category = CategoryType.CAFE_FEATURE,
+                                optionList = listOf(cafeOption)
+                            )
+                        )
+                    }
                 }
             }
             false -> {

--- a/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/UploadPlaceViewModel.kt
+++ b/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/UploadPlaceViewModel.kt
@@ -270,6 +270,13 @@ class UploadPlaceViewModel @Inject constructor(
         }
     }
 
+    fun onSlideAnimationEnd(route: String) = intent {
+        reduce {
+            val updatedMap = state.hasAnimated.toMutableMap().apply { this[route] = true }
+            state.copy(hasAnimated = updatedMap)
+        }
+    }
+
     fun onNavigateToBack() = intent {
         postSideEffect(UploadPlaceSideEffect.OnNavigateToBack)
     }
@@ -338,7 +345,6 @@ class UploadPlaceViewModel @Inject constructor(
         onSuccess:() -> Unit,
         imageList: List<String> = emptyList()
     ) = intent {
-
         uploadRepository.submitUploadPlace(
             spotName = state.selectedSpotByMap?.title ?: "",
             address = state.selectedSpotByMap?.address ?: "",
@@ -438,6 +444,7 @@ class UploadPlaceViewModel @Inject constructor(
 
 @Immutable
 data class UploadPlaceUiState(
+    val hasAnimated: Map<String, Boolean> = emptyMap(),
     val isPreviousBtnEnabled: Boolean = false,
     val isNextBtnEnabled: Boolean = false,
     val showExitUploadPlaceDialog: Boolean = false,

--- a/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/composable/add/UploadPlaceScreen.kt
+++ b/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/composable/add/UploadPlaceScreen.kt
@@ -75,7 +75,11 @@ fun UploadPlaceScreen(
     val currentStep = state.currentStep
 
     BackHandler {
-        viewModel.onRequestExitUploadPlaceDialog()
+        if(currentStep != maxStepIndex) {
+            viewModel.onRequestExitUploadPlaceDialog()
+        } else {
+            viewModel.onNavigateToBack()
+        }
     }
 
     viewModel.collectSideEffect {
@@ -112,7 +116,7 @@ fun UploadPlaceScreen(
         AconTwoActionDialog(
             title = stringResource(R.string.upload_place_exit),
             action1 = stringResource(R.string.cancel),
-            action2 = stringResource(R.string.exit),
+            action2 = stringResource(R.string.quit),
             onDismissRequest = {},
             onAction1 = {
                 viewModel.onDismissExitUploadPlaceDialog()
@@ -120,7 +124,9 @@ fun UploadPlaceScreen(
             onAction2 = {
                 viewModel.onNavigateToBack()
             },
-            modifier = Modifier.width(dialogWidth)
+            isTextAlign = true,
+            modifier = Modifier
+                .width(dialogWidth)
         )
     }
 

--- a/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/composable/add/UploadPlaceScreen.kt
+++ b/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/composable/add/UploadPlaceScreen.kt
@@ -5,6 +5,7 @@ import android.net.Uri
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.SizeTransform
+import androidx.compose.animation.core.tween
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.animation.togetherWith
@@ -58,6 +59,7 @@ import com.acon.acon.feature.upload.screen.composable.menu.UploadPlaceEnterMenuS
 import org.orbitmvi.orbit.compose.collectAsState
 import org.orbitmvi.orbit.compose.collectSideEffect
 
+private const val animationDuration = 500
 private const val maxStepIndex = 6
 
 @Composable
@@ -186,9 +188,23 @@ fun UploadPlaceScreen(
                     targetState = currentStep,
                     transitionSpec = {
                         if (targetState > initialState) {
-                            slideInVertically { height -> height } togetherWith slideOutVertically { height -> -height }
+                            slideInVertically(
+                                animationSpec = tween(durationMillis = animationDuration)
+                            ) { height -> height }
+                                .togetherWith(
+                                    slideOutVertically(
+                                        animationSpec = tween(durationMillis = animationDuration)
+                                    ) { height -> -height }
+                                )
                         } else {
-                            slideInVertically { height -> -height } togetherWith slideOutVertically { height -> height }
+                            slideInVertically(
+                                animationSpec = tween(durationMillis = animationDuration)
+                            ) { height -> -height }
+                                .togetherWith(
+                                    slideOutVertically(animationSpec = tween(durationMillis = animationDuration)) {
+                                        height -> height
+                                    }
+                                )
                         }.using(SizeTransform(clip = true))
                     },
                     label = stringResource(R.string.upload_process_step_transition),

--- a/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/composable/add/UploadPlaceScreen.kt
+++ b/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/composable/add/UploadPlaceScreen.kt
@@ -196,28 +196,33 @@ fun UploadPlaceScreen(
                             onClickReportPlace = viewModel::onClickReportPlace,
                             onHideSearchedPlaceList = viewModel::onHideSearchedPlaceList,
                             onSearchedSpotClick = viewModel::onSearchSpotByMapClicked,
-                            onSearchQueryOrSelectionChanged = viewModel::onSearchQueryOrSelectionChanged
+                            onSearchQueryOrSelectionChanged = viewModel::onSearchQueryOrSelectionChanged,
+                            onAnimationEnded = viewModel::onSlideAnimationEnd
                         )
                         1 -> UploadSelectPlaceScreen(
                             state = state,
                             onSelectSpotType = viewModel::updateSpotType,
-                            onUpdateNextPageBtnEnabled = viewModel::updateNextBtnEnabled
+                            onUpdateNextPageBtnEnabled = viewModel::updateNextBtnEnabled,
+                            //onAnimationEnded = viewModel::onSlideAnimationEnd
                         )
                         2 -> UploadSelectPlaceDetailScreen(
                             state = state,
                             onUpdateCafeOptionType = viewModel::updateCafeOptionType,
                             onUpdateRestaurantType = viewModel::updateRestaurantType,
-                            onUpdateNextPageBtnEnabled = viewModel::updateNextBtnEnabled
+                            onUpdateNextPageBtnEnabled = viewModel::updateNextBtnEnabled,
+                            //onAnimationEnded = viewModel::onSlideAnimationEnd
                         )
                         3 -> UploadPlaceEnterMenuScreen(
                             state = state,
                             onSearchQueryChanged = viewModel::onSearchQueryChanged,
-                            onUpdateNextPageBtnEnabled = viewModel::updateNextBtnEnabled
+                            onUpdateNextPageBtnEnabled = viewModel::updateNextBtnEnabled,
+                            //onAnimationEnded = viewModel::onSlideAnimationEnd
                         )
                         4 -> UploadSelectPriceScreen(
                             state = state,
                             onUpdatePriceOptionType = viewModel::updatePriceOptionType,
-                            onUpdateNextPageBtnEnabled = viewModel::updateNextBtnEnabled
+                            onUpdateNextPageBtnEnabled = viewModel::updateNextBtnEnabled,
+                            //onAnimationEnded = viewModel::onSlideAnimationEnd
                         )
                         5 -> UploadPlaceImageScreen(
                             state = state,
@@ -226,10 +231,12 @@ fun UploadPlaceScreen(
                             onAddSpotImageUri = viewModel::onAddImageUris,
                             onRemoveSpotImageUri = viewModel::onRemoveImageUri,
                             onUpdateNextPageBtnEnabled = viewModel::updateNextBtnEnabled,
-                            onRequestUploadPlaceLimitPouUp = viewModel::onRequestUploadPlaceLimitPouUp
+                            onRequestUploadPlaceLimitPouUp = viewModel::onRequestUploadPlaceLimitPouUp,
+                            //onAnimationEnded = viewModel::onSlideAnimationEnd
                         )
                         6 -> UploadPlaceCompleteScreen(
-                            onClickGoHome = viewModel::onNavigateToBack
+                            onClickGoHome = viewModel::onNavigateToBack,
+                            //onAnimationEnded = viewModel::onSlideAnimationEnd
                         )
                     }
                 }

--- a/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/composable/add/UploadPlaceScreen.kt
+++ b/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/composable/add/UploadPlaceScreen.kt
@@ -203,26 +203,26 @@ fun UploadPlaceScreen(
                             state = state,
                             onSelectSpotType = viewModel::updateSpotType,
                             onUpdateNextPageBtnEnabled = viewModel::updateNextBtnEnabled,
-                            //onAnimationEnded = viewModel::onSlideAnimationEnd
+                            onAnimationEnded = viewModel::onSlideAnimationEnd
                         )
                         2 -> UploadSelectPlaceDetailScreen(
                             state = state,
                             onUpdateCafeOptionType = viewModel::updateCafeOptionType,
                             onUpdateRestaurantType = viewModel::updateRestaurantType,
                             onUpdateNextPageBtnEnabled = viewModel::updateNextBtnEnabled,
-                            //onAnimationEnded = viewModel::onSlideAnimationEnd
+                            onAnimationEnded = viewModel::onSlideAnimationEnd
                         )
                         3 -> UploadPlaceEnterMenuScreen(
                             state = state,
                             onSearchQueryChanged = viewModel::onSearchQueryChanged,
                             onUpdateNextPageBtnEnabled = viewModel::updateNextBtnEnabled,
-                            //onAnimationEnded = viewModel::onSlideAnimationEnd
+                            onAnimationEnded = viewModel::onSlideAnimationEnd
                         )
                         4 -> UploadSelectPriceScreen(
                             state = state,
                             onUpdatePriceOptionType = viewModel::updatePriceOptionType,
                             onUpdateNextPageBtnEnabled = viewModel::updateNextBtnEnabled,
-                            //onAnimationEnded = viewModel::onSlideAnimationEnd
+                            onAnimationEnded = viewModel::onSlideAnimationEnd
                         )
                         5 -> UploadPlaceImageScreen(
                             state = state,
@@ -232,11 +232,10 @@ fun UploadPlaceScreen(
                             onRemoveSpotImageUri = viewModel::onRemoveImageUri,
                             onUpdateNextPageBtnEnabled = viewModel::updateNextBtnEnabled,
                             onRequestUploadPlaceLimitPouUp = viewModel::onRequestUploadPlaceLimitPouUp,
-                            //onAnimationEnded = viewModel::onSlideAnimationEnd
+                            onAnimationEnded = viewModel::onSlideAnimationEnd
                         )
                         6 -> UploadPlaceCompleteScreen(
                             onClickGoHome = viewModel::onNavigateToBack,
-                            //onAnimationEnded = viewModel::onSlideAnimationEnd
                         )
                     }
                 }

--- a/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/composable/add/image/UploadPlaceImageScreen.kt
+++ b/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/composable/add/image/UploadPlaceImageScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import com.acon.acon.core.designsystem.R
+import com.acon.acon.core.designsystem.animation.slideUpAnimation
 import com.acon.acon.core.designsystem.component.dialog.v2.AconTwoActionDialog
 import com.acon.acon.core.designsystem.component.popup.CustomToast
 import com.acon.acon.core.designsystem.effect.LocalHazeState
@@ -58,8 +59,10 @@ internal fun UploadPlaceImageScreen(
     onAddSpotImageUri:(uris: List<Uri>) -> Unit,
     onRemoveSpotImageUri:(uri: Uri) -> Unit,
     onUpdateNextPageBtnEnabled: (Boolean) -> Unit,
-    onRequestUploadPlaceLimitPouUp: () -> Unit
+    onRequestUploadPlaceLimitPouUp: () -> Unit,
+    onAnimationEnded: (String) -> Unit
 ) {
+    val hasAnimated = state.hasAnimated["7"] ?: false
     val selectedUris = state.selectedImageUris ?: emptyList()
 
     val screenHeightDp = getScreenHeight()
@@ -141,7 +144,9 @@ internal fun UploadPlaceImageScreen(
             text = stringResource(R.string.optional_field),
             style = AconTheme.typography.Body1,
             color = AconTheme.color.Gray300,
-            modifier = Modifier.padding(top = 40.dp)
+            modifier = Modifier
+                .padding(top = 40.dp)
+                .then(if (!hasAnimated) Modifier.slideUpAnimation(order = 1) else Modifier)
         )
 
         Spacer(Modifier.height(4.dp))
@@ -149,16 +154,28 @@ internal fun UploadPlaceImageScreen(
             text = stringResource(R.string.upload_place_image_title),
             style = AconTheme.typography.Headline3,
             color = AconTheme.color.White,
-            modifier = Modifier.padding(2.dp)
+            modifier = Modifier
+                .padding(2.dp)
+                .then(if (!hasAnimated) Modifier.slideUpAnimation(order = 2) else Modifier)
         )
 
         Spacer(Modifier.height(32.dp))
-        Box {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(imageBoxHeight)
+                .clip(RoundedCornerShape(10.dp))
+                .then(
+                    if (!hasAnimated) Modifier.slideUpAnimation(
+                        order = 4,
+                        onAnimationEnded = { onAnimationEnded("7") }
+                    ) else Modifier
+                )
+        ) {
             if (selectedUris.isEmpty()) {
                 Box(
                     modifier = Modifier
-                        .fillMaxWidth()
-                        .height(imageBoxHeight)
+                        .fillMaxSize()
                         .clip(RoundedCornerShape(10.dp))
                         .background(AconTheme.color.GlassWhiteDisabled)
                         .aspectRatio(1f)
@@ -272,7 +289,8 @@ private fun UploadPlaceImageScreenPreview() {
             onAddSpotImageUri = {},
             onRemoveSpotImageUri = {},
             onUpdateNextPageBtnEnabled = {},
-            onRequestUploadPlaceLimitPouUp = {}
+            onRequestUploadPlaceLimitPouUp = {},
+            onAnimationEnded = {}
         )
     }
 }

--- a/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/composable/add/place/UploadSelectPlaceDetailScreen.kt
+++ b/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/composable/add/place/UploadSelectPlaceDetailScreen.kt
@@ -27,6 +27,7 @@ import com.acon.acon.core.designsystem.theme.AconTheme
 import com.acon.acon.core.model.type.CafeFeatureType
 import com.acon.acon.core.model.type.RestaurantFeatureType
 import com.acon.acon.core.model.type.SpotType
+import com.acon.acon.feature.upload.screen.SelectedFeature
 import com.acon.acon.feature.upload.screen.UploadPlaceUiState
 import com.acon.acon.feature.upload.screen.composable.add.UploadPlaceSelectItem
 import com.acon.acon.feature.upload.screen.composable.type.getNameResId
@@ -49,10 +50,10 @@ internal fun UploadSelectPlaceDetailScreen(
 
     val isNextPageBtnEnabled by remember(state) {
         derivedStateOf {
-            when (state.selectedSpotType) {
-                SpotType.RESTAURANT -> state.selectedRestaurantTypes.isNotEmpty()
-                SpotType.CAFE -> state.selectedCafeOption != null
-                else -> false
+            when(val feature = state.selectedFeature) {
+                is SelectedFeature.Restaurant -> feature.types.isNotEmpty()
+                is SelectedFeature.Cafe -> true
+                null -> false
             }
         }
     }
@@ -124,7 +125,7 @@ internal fun UploadSelectPlaceDetailScreen(
                                 UploadPlaceSelectItem(
                                     title = stringResource(id = restaurantType.getNameResId()),
                                     modifier = Modifier.weight(1f),
-                                    isSelected = state.selectedRestaurantTypes.contains(restaurantType),
+                                    isSelected = (state.selectedFeature as? SelectedFeature.Restaurant)?.types?.contains(restaurantType) == true,
                                     onClickUploadPlaceSelectItem = {
                                         onUpdateRestaurantType(restaurantType)
                                     }
@@ -172,14 +173,14 @@ internal fun UploadSelectPlaceDetailScreen(
                 ) {
                     UploadPlaceSelectItem(
                         title = stringResource(CafeFeatureType.CafeType.WORK_FRIENDLY.getNameResId()),
-                        isSelected = state.selectedCafeOption == CafeFeatureType.CafeType.WORK_FRIENDLY,
+                        isSelected = (state.selectedFeature as? SelectedFeature.Cafe)?.option == CafeFeatureType.CafeType.WORK_FRIENDLY,
                         onClickUploadPlaceSelectItem = {
                             onUpdateCafeOptionType(CafeFeatureType.CafeType.WORK_FRIENDLY)
                         }
                     )
                     UploadPlaceSelectItem(
                         title = stringResource(CafeFeatureType.CafeType.NOT_GOOD_FOR_WORK.getNameResId()),
-                        isSelected = state.selectedCafeOption == CafeFeatureType.CafeType.NOT_GOOD_FOR_WORK,
+                        isSelected = (state.selectedFeature as? SelectedFeature.Cafe)?.option == CafeFeatureType.CafeType.NOT_GOOD_FOR_WORK,
                         onClickUploadPlaceSelectItem = {
                             onUpdateCafeOptionType(CafeFeatureType.CafeType.NOT_GOOD_FOR_WORK)
                         }

--- a/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/composable/add/place/UploadSelectPlaceDetailScreen.kt
+++ b/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/composable/add/place/UploadSelectPlaceDetailScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.fastForEach
 import com.acon.acon.core.designsystem.R
+import com.acon.acon.core.designsystem.animation.slideUpAnimation
 import com.acon.acon.core.designsystem.theme.AconTheme
 import com.acon.acon.core.model.type.CafeFeatureType
 import com.acon.acon.core.model.type.RestaurantFeatureType
@@ -36,8 +37,12 @@ internal fun UploadSelectPlaceDetailScreen(
     state: UploadPlaceUiState,
     onUpdateCafeOptionType: (CafeFeatureType.CafeType) -> Unit,
     onUpdateRestaurantType: (RestaurantFeatureType.RestaurantType) -> Unit,
-    onUpdateNextPageBtnEnabled: (Boolean) -> Unit
+    onUpdateNextPageBtnEnabled: (Boolean) -> Unit,
+    onAnimationEnded: (String) -> Unit
 ) {
+    val hasAnimatedRestaurant = state.hasAnimated["3"] ?: false
+    val hasAnimatedCafe = state.hasAnimated["4"] ?: false
+
     val allRestaurantTypes = remember {
         persistentListOf(*RestaurantFeatureType.RestaurantType.entries.toTypedArray())
     }
@@ -68,14 +73,17 @@ internal fun UploadSelectPlaceDetailScreen(
                     text = stringResource(R.string.required_field),
                     style = AconTheme.typography.Body1,
                     color = AconTheme.color.Danger,
-                    modifier = Modifier.padding(top = 40.dp)
+                    modifier = Modifier
+                        .padding(top = 40.dp)
+                        .then(if (!hasAnimatedRestaurant) Modifier.slideUpAnimation(order = 1) else Modifier)
                 )
 
                 Spacer(Modifier.height(4.dp))
                 Text(
                     text = stringResource(R.string.upload_place_select_restaurant_title),
                     style = AconTheme.typography.Headline3,
-                    color = AconTheme.color.White
+                    color = AconTheme.color.White,
+                    modifier = Modifier.then(if (!hasAnimatedRestaurant) Modifier.slideUpAnimation(order = 2) else Modifier)
                 )
 
                 Spacer(Modifier.height(10.dp))
@@ -83,14 +91,28 @@ internal fun UploadSelectPlaceDetailScreen(
                     text = stringResource(R.string.upload_place_select_cafe_sub_title),
                     style = AconTheme.typography.Title5,
                     color = AconTheme.color.Gray500,
-                    fontWeight = FontWeight.Normal
+                    fontWeight = FontWeight.Normal,
+                    modifier = Modifier
+                        .then(
+                            if (!hasAnimatedRestaurant) Modifier.slideUpAnimation(
+                                hasCaption = true,
+                                order = 3
+                            ) else Modifier
+                        )
                 )
 
                 Spacer(Modifier.height(32.dp))
                 Column(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(horizontal = 4.dp),
+                        .padding(horizontal = 4.dp)
+                        .then(
+                            if (!hasAnimatedRestaurant) Modifier.slideUpAnimation(
+                                hasCaption = true,
+                                order = 4,
+                                onAnimationEnded = { onAnimationEnded("3") }
+                            ) else Modifier
+                        ),
                     verticalArrangement = Arrangement.spacedBy(10.dp)
                 ) {
                     allRestaurantTypes.chunked(2).fastForEach { pair ->
@@ -118,21 +140,34 @@ internal fun UploadSelectPlaceDetailScreen(
                     text = stringResource(R.string.required_field),
                     style = AconTheme.typography.Body1,
                     color = AconTheme.color.Danger,
-                    modifier = Modifier.padding(top = 40.dp)
+                    modifier = Modifier
+                        .padding(top = 40.dp)
+                        .then(if (!hasAnimatedCafe) Modifier.slideUpAnimation(order = 1) else Modifier)
+
+
                 )
 
                 Spacer(Modifier.height(10.dp))
                 Text(
                     text = stringResource(R.string.upload_place_select_restaurant_cafe),
                     style = AconTheme.typography.Headline3,
-                    color = AconTheme.color.White
+                    color = AconTheme.color.White,
+                    modifier = Modifier
+                        .then(if (!hasAnimatedCafe) Modifier.slideUpAnimation(order = 2) else Modifier)
                 )
 
                 Spacer(Modifier.height(32.dp))
                 Column(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(horizontal = 8.dp),
+                        .padding(horizontal = 8.dp)
+                        .then(
+                            if (!hasAnimatedCafe) Modifier.slideUpAnimation(
+                                hasCaption = false,
+                                order = 4,
+                                onAnimationEnded = { onAnimationEnded("4") }
+                            ) else Modifier
+                        ),
                     verticalArrangement = Arrangement.spacedBy(12.dp)
                 ) {
                     UploadPlaceSelectItem(
@@ -165,7 +200,8 @@ private fun UploadSelectPlaceDetailScreenPreview() {
             state = UploadPlaceUiState(),
             onUpdateCafeOptionType = {},
             onUpdateRestaurantType = {},
-            onUpdateNextPageBtnEnabled = {}
+            onUpdateNextPageBtnEnabled = {},
+            onAnimationEnded = {}
         )
     }
 }

--- a/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/composable/add/place/UploadSelectPlaceDetailScreen.kt
+++ b/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/composable/add/place/UploadSelectPlaceDetailScreen.kt
@@ -171,10 +171,10 @@ internal fun UploadSelectPlaceDetailScreen(
                     verticalArrangement = Arrangement.spacedBy(12.dp)
                 ) {
                     UploadPlaceSelectItem(
-                        title = stringResource(CafeFeatureType.CafeType.GOOD_FOR_WORK.getNameResId()),
-                        isSelected = state.selectedCafeOption == CafeFeatureType.CafeType.GOOD_FOR_WORK,
+                        title = stringResource(CafeFeatureType.CafeType.WORK_FRIENDLY.getNameResId()),
+                        isSelected = state.selectedCafeOption == CafeFeatureType.CafeType.WORK_FRIENDLY,
                         onClickUploadPlaceSelectItem = {
-                            onUpdateCafeOptionType(CafeFeatureType.CafeType.GOOD_FOR_WORK)
+                            onUpdateCafeOptionType(CafeFeatureType.CafeType.WORK_FRIENDLY)
                         }
                     )
                     UploadPlaceSelectItem(

--- a/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/composable/add/place/UploadSelectPlaceScreen.kt
+++ b/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/composable/add/place/UploadSelectPlaceScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.acon.acon.core.designsystem.R
+import com.acon.acon.core.designsystem.animation.slideUpAnimation
 import com.acon.acon.core.designsystem.theme.AconTheme
 import com.acon.acon.core.model.type.SpotType
 import com.acon.acon.feature.upload.screen.UploadPlaceUiState
@@ -30,8 +31,11 @@ import com.acon.acon.feature.upload.screen.composable.type.getNameResId
 internal fun UploadSelectPlaceScreen(
     state: UploadPlaceUiState,
     onSelectSpotType: (SpotType) -> Unit,
-    onUpdateNextPageBtnEnabled: (Boolean) -> Unit
+    onUpdateNextPageBtnEnabled: (Boolean) -> Unit,
+    onAnimationEnded: (String) -> Unit
 ) {
+    val hasAnimated = state.hasAnimated["2"] ?: false
+
     val isNextPageBtnEnabled by remember(state) {
         derivedStateOf {
             state.selectedSpotType != null
@@ -52,14 +56,17 @@ internal fun UploadSelectPlaceScreen(
             text = stringResource(R.string.required_field),
             style = AconTheme.typography.Body1,
             color = AconTheme.color.Danger,
-            modifier = Modifier.padding(top = 40.dp)
+            modifier = Modifier
+                .padding(top = 40.dp)
+                .then(if (!hasAnimated) Modifier.slideUpAnimation(order = 1) else Modifier)
         )
 
         Spacer(Modifier.height(4.dp))
         Text(
             text = stringResource(R.string.upload_place_select_place_title),
             style = AconTheme.typography.Headline3,
-            color = AconTheme.color.White
+            color = AconTheme.color.White,
+            modifier = Modifier.then(if (!hasAnimated) Modifier.slideUpAnimation(order = 2) else Modifier)
         )
 
         Spacer(Modifier.height(10.dp))
@@ -67,14 +74,28 @@ internal fun UploadSelectPlaceScreen(
             text = stringResource(R.string.upload_place_select_place_sub_title),
             style = AconTheme.typography.Title5,
             color = AconTheme.color.Gray500,
-            fontWeight = FontWeight.Normal
+            fontWeight = FontWeight.Normal,
+            modifier = Modifier
+                .then(
+                    if (!hasAnimated) Modifier.slideUpAnimation(
+                        hasCaption = true,
+                        order = 3
+                    ) else Modifier
+                )
         )
 
         Spacer(Modifier.height(32.dp))
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 8.dp),
+                .padding(horizontal = 8.dp)
+                .then(
+                    if (!hasAnimated) Modifier.slideUpAnimation(
+                        hasCaption = true,
+                        order = 4,
+                        onAnimationEnded = { onAnimationEnded("2") }
+                    ) else Modifier
+                ),
             verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
             UploadPlaceSelectItem(
@@ -103,6 +124,7 @@ private fun UploadSelectPlaceScreenPreview() {
             state = UploadPlaceUiState(),
             onSelectSpotType = {},
             onUpdateNextPageBtnEnabled = {},
+            onAnimationEnded = {}
         )
     }
 }

--- a/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/composable/add/price/UploadSelectPriceScreen.kt
+++ b/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/composable/add/price/UploadSelectPriceScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.acon.acon.core.designsystem.R
+import com.acon.acon.core.designsystem.animation.slideUpAnimation
 import com.acon.acon.core.designsystem.theme.AconTheme
 import com.acon.acon.core.model.type.PriceFeatureType
 import com.acon.acon.feature.upload.screen.UploadPlaceUiState
@@ -29,8 +30,11 @@ import com.acon.acon.feature.upload.screen.composable.type.getNameResId
 internal fun UploadSelectPriceScreen(
     state: UploadPlaceUiState,
     onUpdatePriceOptionType: (PriceFeatureType.PriceOptionType) -> Unit,
-    onUpdateNextPageBtnEnabled: (Boolean) -> Unit
+    onUpdateNextPageBtnEnabled: (Boolean) -> Unit,
+    onAnimationEnded: (String) -> Unit
 ) {
+    val hasAnimated = state.hasAnimated["6"] ?: false
+
     val isNextPageBtnEnabled by remember(state) {
         derivedStateOf {
             state.selectedPriceOption != null
@@ -51,7 +55,9 @@ internal fun UploadSelectPriceScreen(
             text = stringResource(R.string.required_field),
             style = AconTheme.typography.Body1,
             color = AconTheme.color.Danger,
-            modifier = Modifier.padding(top = 40.dp)
+            modifier = Modifier
+                .padding(top = 40.dp)
+                .then(if (!hasAnimated) Modifier.slideUpAnimation(order = 1) else Modifier)
         )
 
         Spacer(Modifier.height(4.dp))
@@ -59,14 +65,23 @@ internal fun UploadSelectPriceScreen(
             text = stringResource(R.string.upload_place_select_price_title),
             style = AconTheme.typography.Headline3,
             color = AconTheme.color.White,
-            modifier = Modifier.padding(2.dp)
+            modifier = Modifier
+                .padding(2.dp)
+                .then(if (!hasAnimated) Modifier.slideUpAnimation(order = 2) else Modifier)
         )
 
         Spacer(Modifier.height(32.dp))
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 8.dp),
+                .padding(horizontal = 8.dp)
+                .then(
+                    if (!hasAnimated) Modifier.slideUpAnimation(
+                        hasCaption = true,
+                        order = 3,
+                        onAnimationEnded = { onAnimationEnded("6") }
+                    ) else Modifier
+                ),
             verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
             UploadPlaceSelectItem(
@@ -103,7 +118,8 @@ private fun UploadSelectPriceScreenPreview(
         UploadSelectPriceScreen(
             state = UploadPlaceUiState(),
             onUpdatePriceOptionType = {},
-            onUpdateNextPageBtnEnabled = {}
+            onUpdateNextPageBtnEnabled = {},
+            onAnimationEnded = {}
         )
     }
 }

--- a/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/composable/add/search/UploadPlaceSearchScreen.kt
+++ b/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/composable/add/search/UploadPlaceSearchScreen.kt
@@ -100,8 +100,6 @@ internal fun UploadPlaceSearchScreen(
         }
     }
 
-    state.hasAnimated
-
     LaunchedEffect(lifecycleOwner, Unit) {
         lifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.RESUMED) {
             if (state.selectedSpotByMap?.title?.isNotEmpty() == true) {
@@ -202,7 +200,6 @@ internal fun UploadPlaceSearchScreen(
                     .fillMaxWidth()
                     .then(
                         if (!hasAnimated) Modifier.slideUpAnimation(
-                            hasCaption = false,
                             order = 4,
                             onAnimationEnded = { onAnimationEnded("1") }
                         ) else Modifier

--- a/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/composable/menu/UploadEnterMenuScreen.kt
+++ b/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/composable/menu/UploadEnterMenuScreen.kt
@@ -86,9 +86,11 @@ internal fun UploadEnterMenuScreen(
         Spacer(Modifier.height(32.dp))
         AconSearchTextField(
             value = query,
-            onValueChange = {
-                query = it
-                isSelection = false
+            onValueChange = { newValue ->
+                if (newValue.text.length <= 30) {
+                    query = newValue
+                    isSelection = false
+                }
             },
             keyboardOptions = KeyboardOptions(
                 imeAction = ImeAction.Done,

--- a/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/composable/menu/UploadPlaceEnterMenuScreen.kt
+++ b/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/composable/menu/UploadPlaceEnterMenuScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.acon.acon.core.designsystem.R
+import com.acon.acon.core.designsystem.animation.slideUpAnimation
 import com.acon.acon.core.designsystem.component.textfield.v2.AconOutlinedSearchTextField
 import com.acon.acon.core.designsystem.theme.AconTheme
 import com.acon.acon.feature.upload.screen.UploadPlaceUiState
@@ -38,8 +39,11 @@ import com.acon.acon.feature.upload.screen.UploadPlaceUiState
 internal fun UploadPlaceEnterMenuScreen(
     state: UploadPlaceUiState,
     onSearchQueryChanged: (String) -> Unit,
-    onUpdateNextPageBtnEnabled: (Boolean) -> Unit
+    onUpdateNextPageBtnEnabled: (Boolean) -> Unit,
+    onAnimationEnded: (String) -> Unit
 ) {
+    val hasAnimated = state.hasAnimated["5"] ?: false
+
     val focusManager = LocalFocusManager.current
     val keyboardController = LocalSoftwareKeyboardController.current
 
@@ -65,42 +69,57 @@ internal fun UploadPlaceEnterMenuScreen(
             })
         }
     ) {
-        Text(
-            text = stringResource(R.string.required_field),
-            style = AconTheme.typography.Body1,
-            color = AconTheme.color.Danger,
-            modifier = Modifier.padding(top = 40.dp)
-        )
+        Column {
+            Text(
+                text = stringResource(R.string.required_field),
+                style = AconTheme.typography.Body1,
+                color = AconTheme.color.Danger,
+                modifier = Modifier
+                    .padding(top = 40.dp)
+                    .then(if (!hasAnimated) Modifier.slideUpAnimation(order = 1) else Modifier)
+            )
 
-        Text(
-            text = stringResource(R.string.upload_place_enter_menu_title),
-            style = AconTheme.typography.Headline3,
-            color = AconTheme.color.White,
-            modifier = Modifier.padding(top = 4.dp, start = 2.dp)
-        )
+            Text(
+                text = stringResource(R.string.upload_place_enter_menu_title),
+                style = AconTheme.typography.Headline3,
+                color = AconTheme.color.White,
+                modifier = Modifier
+                    .padding(top = 4.dp, start = 2.dp)
+                    .then(if (!hasAnimated) Modifier.slideUpAnimation(order = 2) else Modifier)
+            )
 
-        Spacer(Modifier.height(32.dp))
-        AconOutlinedSearchTextField(
-            value = query,
-            onValueChange = { newValue ->
-                if (newValue.text.length <= 20) {
-                    query = newValue
-                    isSelection = false
-                }
-            },
-            keyboardOptions = KeyboardOptions(
-                imeAction = ImeAction.Done,
-                keyboardType = KeyboardType.Text
-            ),
-            keyboardActions = KeyboardActions(
-                onDone = {
-                    keyboardController?.hide()
-                    focusManager.clearFocus()
-                }
-            ),
-            placeholder = stringResource(R.string.upload_place_enter_menu_placeholder),
-            modifier = Modifier.fillMaxWidth()
-        )
+            Spacer(Modifier.height(32.dp))
+        }
+        Column {
+            AconOutlinedSearchTextField(
+                value = query,
+                onValueChange = { newValue ->
+                    if (newValue.text.length <= 20) {
+                        query = newValue
+                        isSelection = false
+                    }
+                },
+                keyboardOptions = KeyboardOptions(
+                    imeAction = ImeAction.Done,
+                    keyboardType = KeyboardType.Text
+                ),
+                keyboardActions = KeyboardActions(
+                    onDone = {
+                        keyboardController?.hide()
+                        focusManager.clearFocus()
+                    }
+                ),
+                placeholder = stringResource(R.string.upload_place_enter_menu_placeholder),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .then(
+                        if (!hasAnimated) Modifier.slideUpAnimation(
+                            order = 4,
+                            onAnimationEnded = { onAnimationEnded("5") }
+                        ) else Modifier
+                    )
+            )
+        }
     }
 }
 
@@ -111,7 +130,8 @@ private fun UploadPlaceEnterMenuScreenPreview() {
         UploadPlaceEnterMenuScreen(
             state = UploadPlaceUiState(),
             onSearchQueryChanged = {},
-            onUpdateNextPageBtnEnabled = {}
+            onUpdateNextPageBtnEnabled = {},
+            onAnimationEnded = {}
         )
     }
 }

--- a/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/composable/menu/UploadPlaceEnterMenuScreen.kt
+++ b/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/composable/menu/UploadPlaceEnterMenuScreen.kt
@@ -94,7 +94,7 @@ internal fun UploadPlaceEnterMenuScreen(
             AconOutlinedSearchTextField(
                 value = query,
                 onValueChange = { newValue ->
-                    if (newValue.text.length <= 20) {
+                    if (newValue.text.length <= 30) {
                         query = newValue
                         isSelection = false
                     }

--- a/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/composable/type/TypeExtensions.kt
+++ b/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/composable/type/TypeExtensions.kt
@@ -38,7 +38,7 @@ internal fun RestaurantFeatureType.RestaurantType.getNameResId(): Int {
 
 internal fun CafeFeatureType.CafeType.getNameResId(): Int {
     return when(this) {
-        CafeFeatureType.CafeType.GOOD_FOR_WORK -> R.string.upload_place_select_cafe_option1
+        CafeFeatureType.CafeType.WORK_FRIENDLY -> R.string.upload_place_select_cafe_option1
         CafeFeatureType.CafeType.NOT_GOOD_FOR_WORK -> R.string.upload_place_select_cafe_option2
     }
 }


### PR DESCRIPTION
## *🧨 Issue*
- closed #

## *💻 Work Description 
- 글자 애니메이션 적용
  - SlideUp 애니메이션 구현
- 장소 업로드 프로세스 애니메이션 속도 조정 (0.5초)

### QA 반영
- 리뷰 등록 api 속도 개선 (10장 기준, 0.4초 정도 걸림)
- 장소 등록 나가기 다이얼로그 문구 수정, 장소 등록 완료 화면에서는 뒤로가기 시, 홈으로 나가기
- 메뉴명 등록 최대 30자로 수정
  - 장소 등록, 리뷰 업로드
-  카페 옵션 선택 그저 그래요 옵션 선택 안되는 것 수정

## *📸 Screenshot*
https://github.com/user-attachments/assets/3af369ab-649a-405a-9ad9-28c78c3287f6

## *💭 To Reviewers*
- SlideUp 애니메이션을 AnimatedVisibility를 사용하면 애니메이션 공간 부족 문제 때문에 애니메이션이 잘려서 실행되서 animateDpAsState를 사용해서 만들었습니다.

- 리뷰 등록 api 속도 개선에서 코드를 수정한 부분 말고, OkHttp 정의한 부분은 AI가 이렇게 하면 더 빠르다고 해서 수정했는데 유의미한 차이가 있는지 잘 모르겠습니다.

- 카페 옵션 선택 그저 그래요 옵션은 서버에서 이 값은 따로 받지 않는다고 해서 null로 보내달라고 해서, 이 옵션을 선택한 경우, emptyList로 보내고 있습니다.

- 장소 등록 api 호출중, 중복 호출을 막기 위해 장소 등록 api 호출 시(다음 버튼 클릭), 버튼을 비활성화 하고, 이후 결과가 온 후에 다시 활성화 되도록 적용했습니다.