### PR TITLE
fix: 장소 등록 api 요청 시, 지번 주소가 없으면 도로명 주소,도로명 주소도 없으면 서버에 빈 문자열 전송

### DIFF
--- a/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/UploadPlaceViewModel.kt
+++ b/feature/upload/src/main/java/com/acon/acon/feature/upload/screen/UploadPlaceViewModel.kt
@@ -346,9 +346,10 @@ class UploadPlaceViewModel @Inject constructor(
         onSuccess:() -> Unit,
         imageList: List<String> = emptyList()
     ) = intent {
+        // 지번 주소가 없으면 도로명 주소, 도로명 주소도 없으면 서버에 빈 문자열 전송
         uploadRepository.submitUploadPlace(
             spotName = state.selectedSpotByMap?.title ?: "",
-            address = state.selectedSpotByMap?.address ?: "",
+            address = state.selectedSpotByMap?.address ?: state.selectedSpotByMap?.roadAddress ?: "",
             spotType = state.selectedSpotType ?: SpotType.CAFE,
             featureList = state.featureList ?: emptyList(),
             recommendedMenu = state.recommendMenu ?: "",


### PR DESCRIPTION
## *🧨 Issue*
- closed #

## *💻 Work Description*
- 장소 등록 api 요청 시, 지번 주소가 없으면 도로명 주소,도로명 주소도 없으면 서버에 빈 문자열 전송

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 버그 수정
  * 장소 업로드 시 기본 주소가 비어있는 경우 도로명 주소를 자동으로 사용하도록 개선했습니다. 이로써 빈 주소로 저장되던 문제를 줄이고, 서버 전송과 목록/상세 화면에서의 주소 표시가 더 정확하고 일관되게 동작합니다. 지도에서 선택한 장소 정보 누락을 방지하고, 업로드 흐름 전반의 예외 상황을 보다 부드럽게 처리합니다. 사용자 개입 없이 올바른 주소가 채워져 재시도 횟수와 입력 부담이 감소합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->